### PR TITLE
Revert #1: Re-add UUID as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iso20022.js",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iso20022.js",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "dinero.js": "^1.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dinero.js": "^1.9.1",
         "fast-xml-parser": "^4.4.1",
+        "uuid": "^10.0.0",
         "xmlbuilder2": "^3.1.1"
       },
       "devDependencies": {
@@ -23,6 +24,7 @@
         "@types/dinero.js": "^1.9.4",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.12",
+        "@types/uuid": "^10.0.0",
         "husky": "^9.1.4",
         "jest": "^29.7.0",
         "libxmljs": "^1.0.11",
@@ -2095,6 +2097,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6487,6 +6496,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iso20022.js",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Simple framework to create and ingest ISO20022 XML files.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/dinero.js": "^1.9.4",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.12",
+    "@types/uuid": "^10.0.0",
     "husky": "^9.1.4",
     "jest": "^29.7.0",
     "libxmljs": "^1.0.11",
@@ -66,6 +67,7 @@
   "dependencies": {
     "dinero.js": "^1.9.1",
     "fast-xml-parser": "^4.4.1",
+    "uuid": "^10.0.0",
     "xmlbuilder2": "^3.1.1"
   }
 }

--- a/src/pain/001/SWIFTCreditPaymentInitiation.ts
+++ b/src/pain/001/SWIFTCreditPaymentInitiation.ts
@@ -1,5 +1,5 @@
 import { create } from 'xmlbuilder2';
-import { randomUUID } from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
 import Dinero, { Currency } from 'dinero.js';
 import {
   Party,
@@ -47,7 +47,7 @@ export class SWIFTCreditPaymentInitiation extends ISO20022PaymentInitiation {
     this.initiatingParty = config.initiatingParty;
     this.paymentInstructions = config.paymentInstructions;
     this.messageId =
-      config.messageId || randomUUID().replace(/-/g, '').substring(0, 35);
+      config.messageId || uuidv4().replace(/-/g, '').substring(0, 35);
     this.creationDate = config.creationDate || new Date();
     this.validate();
   }
@@ -91,7 +91,7 @@ export class SWIFTCreditPaymentInitiation extends ISO20022PaymentInitiation {
    * @returns {Object} The payment information object.
    */
   paymentInformation(paymentInstruction: SWIFTCreditPaymentInstruction) {
-    const paymentInfId = sanitize(paymentInstruction.id || randomUUID(), 35);
+    const paymentInfId = sanitize(paymentInstruction.id || uuidv4(), 35);
     const amount = Dinero({
       amount: paymentInstruction.amount,
       currency: paymentInstruction.currency,


### PR DESCRIPTION
TLDR: I want to use this module using Webpack. 

randomUUID was added into node:crypto in v15, and it isn't support by crypto-browserify sadly. 

I think relying on uuid will be a simple solution that will allow this to work.

- 0.0.7
- added old school uuid module
