### PR TITLE
[Fix #18] Make legal/electronic Sequence Numbers optional

### DIFF
--- a/src/camt/types.ts
+++ b/src/camt/types.ts
@@ -10,9 +10,9 @@ export interface Statement {
   /** Unique identifier for the statement. */
   id: string;
   /** Electronic sequence number of the statement. */
-  electronicSequenceNumber: number;
+  electronicSequenceNumber?: number;
   /** Legal sequence number of the statement. */
-  legalSequenceNumber: number;
+  legalSequenceNumber?: number;
   /** Date and time when the statement was created. */
   creationDate: Date;
   /** Start date of the statement period. */

--- a/test/camt/053/CashManagementEndOfDayReport.test.ts
+++ b/test/camt/053/CashManagementEndOfDayReport.test.ts
@@ -247,7 +247,7 @@ describe('CashManagementEndOfDayReport', () => {
         const xmlFilePath = `${process.cwd()}/test/assets/cross_river/pain_002_transaction_rejected.xml`;
         const pain002Sample = fs.readFileSync(xmlFilePath, 'utf8');
         CashManagementEndOfDayReport.fromXML(pain002Sample);
-      }).toThrow('Invalid XML namespace');
+      }).toThrow('Invalid CAMT.053 namespace');
     });
   });
 });


### PR DESCRIPTION
These fields are optional. They may not be included - for example in the ing/example files.

This PR makes this more obvious in the Statement interface itself.
