### PR TITLE
[Cash Management] Move Recipient from Party to it's own type #21

### DIFF
--- a/src/parseUtils.ts
+++ b/src/parseUtils.ts
@@ -1,4 +1,4 @@
-import { Account, Agent, Party } from 'lib/types';
+import { Account, Agent, Party, StructuredAddress } from 'lib/types';
 import Dinero, { Currency } from 'dinero.js';
 
 export const parseAccount = (account: any): Account => {
@@ -52,6 +52,17 @@ export const parseParty = (party: any): Party => {
     id: party.Id?.OrgId?.Othr?.Id,
     name: party.Nm,
   } as Party;
+};
+
+export const parseRecipient = (recipient: any): {
+  id?: string;
+  name?: string;
+  address?: StructuredAddress
+} => {
+  return {
+    id: recipient.Id?.OrgId?.Othr?.Id,
+    name: recipient.Nm,
+  };
 };
 
 // Standardize into a single string


### PR DESCRIPTION
According to CAMT 053 schema, recipient doesn't contain account / agent information. It's more accurate if we use a separate type instead of using Party. 

https://github.com/Svapnil/iso20022.js/commit/1461181d16f412ff345eb2231a694ae6b8e4b8f1