### PR TITLE
[SEPA] Make paymentInformationId UUID instead of Epoch

### DIFF
--- a/src/pain/001/SEPACreditPaymentInitiation.ts
+++ b/src/pain/001/SEPACreditPaymentInitiation.ts
@@ -142,6 +142,7 @@ export class SEPACreditPaymentInitiation extends PaymentInitiation {
    * @returns {string} The XML representation of the SEPA credit transfer initiation.
    */
   public serialize(): string {
+    const paymentInformationId = sanitize(uuidv4(), 35);
     const xml = {
       Document: {
         '@xmlns': 'urn:iso:std:iso:20022:tech:xsd:pain.001.001.03',
@@ -164,7 +165,7 @@ export class SEPACreditPaymentInitiation extends PaymentInitiation {
             },
           },
           PmtInf: {
-            PmtInfId: `TRF${Date.now()}`,
+            PmtInfId: paymentInformationId,
             PmtMtd: 'TRF',
             NbOfTxs: this.paymentInstructions.length.toString(),
             CtrlSum: this.paymentSum,


### PR DESCRIPTION
The pmtInf block represents a unique batch of transfers that has been created. 

Currently paymentInformation was using Epoch in SEPA. In SWIFT it was using UUID.

This way we are using uuid. 

## Old Version

```
...
    <PmtInf>
      <PmtInfId>TRF1736726640590</PmtInfId>
      <PmtMtd>TRF</PmtMtd>
...
```

## New Version 

```
...
    <PmtInf>
      <PmtInfId>0f945865-e2a7-4235-8081-1dbd15c1bb0</PmtInfId>
      <PmtMtd>TRF</PmtMtd>
...
```