### PR TITLE
[SWIFTCreditPaymentInitiation] Move multiple instructions from Batches to CreditTransfers

### DIFF
--- a/src/iso20022.ts
+++ b/src/iso20022.ts
@@ -1,6 +1,8 @@
 import { Party, SWIFTCreditPaymentInstruction } from './lib/types.js';
 import { SWIFTCreditPaymentInitiation } from './pain/001/SWIFTCreditPaymentInitiation';
 
+type AtLeastOne<T> = [T, ...T[]];
+
 /**
  * Configuration interface for the ISO20022 class.
  * @interface ISO20022Config
@@ -35,7 +37,7 @@ class ISO20022 {
    * @returns {SWIFTCreditPaymentInitiation} A new SWIFT Credit Payment Initiation object.
    */
   createSWIFTCreditPaymentInitiation(
-    paymentInstructions: SWIFTCreditPaymentInstruction[],
+    paymentInstructions: AtLeastOne<SWIFTCreditPaymentInstruction>,
   ) {
     return new SWIFTCreditPaymentInitiation({
       initiatingParty: this.initiatingParty,

--- a/src/pain/001/SEPACreditPaymentInitiation.ts
+++ b/src/pain/001/SEPACreditPaymentInitiation.ts
@@ -110,7 +110,7 @@ export class SEPACreditPaymentInitiation extends PaymentInitiation {
    * @param {SEPACreditPaymentInstruction} instruction - The payment instruction.
    * @returns {Object} The payment information object formatted according to SEPA specifications.
    */
-  paymentInformation(instruction: SEPACreditPaymentInstruction) {
+  creditTransfer(instruction: SEPACreditPaymentInstruction) {
     const paymentInstructionId = sanitize(instruction.id || uuidv4(), 35);
     const dinero = Dinero({ amount: instruction.amount, currency: instruction.currency });
 
@@ -178,7 +178,7 @@ export class SEPACreditPaymentInitiation extends PaymentInitiation {
             DbtrAgt: this.agent(this.initiatingParty.agent as Agent),
             ChrgBr: 'SLEV',
             // payments[]
-            CdtTrfTxInf: this.paymentInstructions.map(p => this.paymentInformation(p)),
+            CdtTrfTxInf: this.paymentInstructions.map(p => this.creditTransfer(p)),
           }
         }
       },

--- a/src/pain/001/SWIFTCreditPaymentInitiation.ts
+++ b/src/pain/001/SWIFTCreditPaymentInitiation.ts
@@ -11,6 +11,8 @@ import {
 import { PaymentInitiation } from './ISO20022PaymentInitiation';
 import { sanitize } from '../../utils/format';
 
+type AtLeastOne<T> = [T, ...T[]];
+
 /**
  * Configuration interface for SWIFTCreditPaymentInitiation.
  * @interface SWIFTCreditPaymentInitiationConfig
@@ -19,7 +21,7 @@ export interface SWIFTCreditPaymentInitiationConfig {
   /** The party initiating the payment. */
   initiatingParty: Party;
   /** An array of payment instructions. */
-  paymentInstructions: SWIFTCreditPaymentInstruction[];
+  paymentInstructions: AtLeastOne<SWIFTCreditPaymentInstruction>;
   /** Optional unique identifier for the message. If not provided, a UUID will be generated. */
   messageId?: string;
   /** Optional creation date for the message. If not provided, current date will be used. */

--- a/test/pain/001/SWIFTCreditPaymentInitiation.test.ts
+++ b/test/pain/001/SWIFTCreditPaymentInitiation.test.ts
@@ -2,50 +2,75 @@ import { SWIFTCreditPaymentInitiation } from '../../../src/pain/001/SWIFTCreditP
 import ISO20022 from '../../../src/iso20022';
 import fs from 'fs';
 import libxmljs from 'libxmljs';
+import { SWIFTCreditPaymentInstruction } from 'index';
 
 describe('SWIFTCreditPaymentInitiation', () => {
   let iso20022: ISO20022;
   let swiftPayment: SWIFTCreditPaymentInitiation;
+  let instruction1 = {
+    type: 'swift',
+    direction: 'credit',
+    amount: 1000,
+    currency: 'USD',
+    creditor: {
+      name: 'John Doe',
+      account: {
+        iban: 'DE1234567890123456',
+      },
+      agent: {
+        bic: 'DEUTDEFF',
+      },
+      address: {
+        streetName: 'Main St',
+        buildingNumber: '123',
+        postalCode: '12345',
+        townName: 'Funkytown',
+        country: 'DE',
+      },
+    },
+  } as SWIFTCreditPaymentInstruction;
+
+  let instruction2 = {
+    type: 'swift',
+    direction: 'credit',
+    amount: 500,
+    currency: 'EUR',
+    creditor: {
+      name: 'Jane Doe',
+      account: {
+        iban: 'DE1234567890123456',
+      },
+      agent: {
+        bic: 'DEUTDEFF',
+      },
+      address: {
+        streetName: 'Main St',
+        buildingNumber: '123',
+        postalCode: '12345',
+        townName: 'Funkytown',
+        country: 'DE',
+      },
+    },
+  } as SWIFTCreditPaymentInstruction;
 
   beforeEach(() => {
-    iso20022 = new ISO20022({
-      initiatingParty: {
-        name: 'Acme Corporation',
-        id: 'ACMEID',
-        account: {
-          accountNumber: '123456789012',
-        },
-        agent: {
-          bic: 'CHASUS33',
-        },
-      },
-    });
-
-    swiftPayment = iso20022.createSWIFTCreditPaymentInitiation([
-      {
-        type: 'swift',
-        direction: 'credit',
-        amount: 1000,
-        currency: 'USD',
-        creditor: {
-          name: 'John Doe',
+      iso20022 = new ISO20022({
+        initiatingParty: {
+          name: 'Acme Corporation',
+          id: 'ACMEID',
           account: {
-            iban: 'DE1234567890123456',
+            accountNumber: '123456789012',
           },
           agent: {
-            bic: 'DEUTDEFF',
-          },
-          address: {
-            streetName: 'Main St',
-            buildingNumber: '123',
-            postalCode: '12345',
-            townName: 'Funkytown',
-            country: 'DE',
+            bic: 'CHASUS33',
           },
         },
-      },
-    ]);
-  });
+      });
+
+      swiftPayment = iso20022.createSWIFTCreditPaymentInitiation([
+        instruction1
+      ]);
+    });
 
   test('should create a SWIFTCreditPaymentInitiation instance', () => {
     expect(swiftPayment).toBeInstanceOf(SWIFTCreditPaymentInitiation);
@@ -68,5 +93,28 @@ describe('SWIFTCreditPaymentInitiation', () => {
 
     const isValid = xmlDoc.validate(xsdDoc);
     expect(isValid).toBeTruthy();
+  });
+
+  describe('when there are multiple payment instructions', () => {
+    beforeEach(() => {
+      swiftPayment = iso20022.createSWIFTCreditPaymentInitiation([
+        instruction1,
+        instruction2,
+      ]);
+    });
+
+    test('serialized XML should validate against XSD', () => {
+      const xml = swiftPayment.serialize();
+      console.log(xml);
+      const xsdSchema = fs.readFileSync(
+        `${process.cwd()}/schemas/pain/pain.001.001.03.xsd`,
+        'utf8',
+      );
+      const xmlDoc = libxmljs.parseXml(xml);
+      const xsdDoc = libxmljs.parseXml(xsdSchema);
+
+      const isValid = xmlDoc.validate(xsdDoc);
+      expect(isValid).toBeTruthy();
+    });
   });
 });

--- a/test/pain/001/SWIFTCreditPaymentInitiation.test.ts
+++ b/test/pain/001/SWIFTCreditPaymentInitiation.test.ts
@@ -105,7 +105,6 @@ describe('SWIFTCreditPaymentInitiation', () => {
 
     test('serialized XML should validate against XSD', () => {
       const xml = swiftPayment.serialize();
-      console.log(xml);
       const xsdSchema = fs.readFileSync(
         `${process.cwd()}/schemas/pain/pain.001.001.03.xsd`,
         'utf8',


### PR DESCRIPTION
### Problem 

A few days ago @daelvn contributed SEPA support to `iso20022.js` - in this working implementation was one key difference:

In this SWIFT implementation, we created multiple `PmtInf` elements. 

In the SEPA implementation, @daelvn created multiple `CdtTrfTxInf` elements. 

The difference is that `PmtInf` delinates *batches* and `CdrTrfTxInf` delineates individual payments.

### Solution

Let's move SWIFT to the technique @daelvn used.

Moving SWIFT to have multiple payment instructions in one batch is more technically correct and in practice can actually save money, since it reduces batches, which sometimes cost money.

### Test

@johanneskares is one of the current known users of SWIFT - get this approval. 

npm run test