### PR TITLE
Add end-to-end ID to transaction details in CAMT

### DIFF
--- a/src/camt/053/utils.ts
+++ b/src/camt/053/utils.ts
@@ -153,6 +153,7 @@ const parseTransactionDetail = (transactionDetail: any): Transaction => {
   const proprietaryPurpose = transactionDetail.Purp?.Prtry;
   const returnReason = transactionDetail.RtrInf?.Rsn;
   const returnAdditionalInformation = transactionDetail.RtrInf?.AddtlInf;
+  const endToEndId = transactionDetail.Refs?.EndToEndId;
 
   // Get Debtor information if 'Dbtr' is present
   let debtor;
@@ -203,6 +204,7 @@ const parseTransactionDetail = (transactionDetail: any): Transaction => {
   return {
     messageId,
     accountServicerReferenceId,
+    endToEndId,
     paymentInformationId,
     remittanceInformation,
     proprietaryPurpose,

--- a/src/camt/types.ts
+++ b/src/camt/types.ts
@@ -118,6 +118,8 @@ export interface Transaction {
   returnReason?: string;
   /** Additional information about the return. */
   returnAdditionalInformation?: string;
+  /** End-to-end ID for the entry. */
+  endToEndId?: string;
 }
 
 // NOTE: We should consider creating DomainCode, FamilyCode, and SubFamilyCode types from:

--- a/test/camt/053/CashManagementEndOfDayReport.test.ts
+++ b/test/camt/053/CashManagementEndOfDayReport.test.ts
@@ -84,6 +84,7 @@ describe('CashManagementEndOfDayReport', () => {
         expect(firstTransaction.paymentInformationId).toBe(
           'RP/GS/CTFILERP0002/CTBA0003',
         );
+        expect(firstTransaction.endToEndId).toBe('GSGWGDNCTAHQM8');
 
         // Account Information
         expect(firstTransaction.remittanceInformation).toBe(


### PR DESCRIPTION
Introduce an end-to-end ID field in transaction details and update related tests accordingly.
Issue/Ticket: #29