### PR TITLE
Fix Critical Amount Number Parsing Error

### DIFF
--- a/src/parseUtils.ts
+++ b/src/parseUtils.ts
@@ -38,7 +38,8 @@ export const parseAmountToMinorUnits = (
   const currencyObject = Dinero({
     currency: currency,
   });
-  return Number(rawAmount) * 10 ** currencyObject.getPrecision();
+  // Also make sure Javascript number parsing error do not happen.
+  return Math.floor(Number(rawAmount) * 10 ** currencyObject.getPrecision());
 };
 
 export const parseDate = (dateElement: any): Date => {

--- a/test/pain/001/sepa-credit-payment-initiation.test.ts
+++ b/test/pain/001/sepa-credit-payment-initiation.test.ts
@@ -44,7 +44,7 @@ describe('SEPACreditPaymentInitiation', () => {
                 country: "ES" as Alpha2CountryCode
             }
         },
-        amount: 1000,
+        amount: 3395,
         currency: "EUR" as const
     }
 


### PR DESCRIPTION
## Issue

When we INGEST xml, either in CAMT files or SEPA files (at this point), we get Amount as a number, where we convert it to minor units (10.00 -> 1000).

The issue is that for some cases, we run into weird floating point issues. 

33.95 -> 3395.00005

This borks Dinero formatting AND is incorrect.

The result is intermittant errors based off SOME information for CAMT parsing, and now SEPA parsing. Should be fixed.

Let's use Math.floor to avoid this error

## Tests

npm run test
