### PR TITLE
Implement RTP Credit Payment Initiation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export type {
   Agent,
   SWIFTCreditPaymentInstruction,
   SEPACreditPaymentInstruction,
+  RTPCreditPaymentInstruction,
   StructuredAddress,
   IBANAccount,
   BaseAccount,
@@ -18,6 +19,8 @@ export type { SWIFTCreditPaymentInitiationConfig } from './pain/001/swift-credit
 export { SWIFTCreditPaymentInitiation } from './pain/001/swift-credit-payment-initiation';
 export type { SEPACreditPaymentInitiationConfig } from './pain/001/sepa-credit-payment-initiation';
 export { SEPACreditPaymentInitiation } from './pain/001/sepa-credit-payment-initiation';
+export type { RTPCreditPaymentInitiationConfig } from './pain/001/rtp-credit-payment-initiation';
+export { RTPCreditPaymentInitiation } from './pain/001/rtp-credit-payment-initiation';
 
 // pain.002
 export type {

--- a/src/iso20022.ts
+++ b/src/iso20022.ts
@@ -1,6 +1,7 @@
-import { Party, SWIFTCreditPaymentInstruction, SEPACreditPaymentInstruction } from './lib/types.js';
+import { Party, SWIFTCreditPaymentInstruction, SEPACreditPaymentInstruction, RTPCreditPaymentInstruction } from './lib/types.js';
 import { SWIFTCreditPaymentInitiation } from './pain/001/swift-credit-payment-initiation';
 import { SEPACreditPaymentInitiation } from './pain/001/sepa-credit-payment-initiation';
+import { RTPCreditPaymentInitiation } from './pain/001/rtp-credit-payment-initiation';
 
 type AtLeastOne<T> = [T, ...T[]];
 
@@ -55,6 +56,20 @@ class ISO20022 {
     paymentInstructions: AtLeastOne<SEPACreditPaymentInstruction>,
   ) {
     return new SEPACreditPaymentInitiation({
+      initiatingParty: this.initiatingParty,
+      paymentInstructions: paymentInstructions,
+    });
+  }
+
+  /**
+   * Creates a RTP Credit Payment Initiation message.
+   * @param {RTPCreditPaymentInstruction[]} paymentInstructions - An array of payment instructions.
+   * @returns {RTPCreditPaymentInitiation} A new RTP Credit Payment Initiation object.
+   */
+  createRTPCreditPaymentInitiation(
+    paymentInstructions: AtLeastOne<RTPCreditPaymentInstruction>,
+  ) {
+    return new RTPCreditPaymentInitiation({
       initiatingParty: this.initiatingParty,
       paymentInstructions: paymentInstructions,
     });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -198,6 +198,13 @@ export interface SEPACreditPaymentInstruction extends PaymentInstruction {
   creditor: Party,
 }
 
+export interface RTPCreditPaymentInstruction extends PaymentInstruction {
+  type: 'rtp',
+  direction: 'credit',
+  currency: 'USD',
+  creditor: Party,
+}
+
 /**
  * Represents a structured address format.
  */

--- a/src/pain/001/iso20022-payment-initiation.ts
+++ b/src/pain/001/iso20022-payment-initiation.ts
@@ -120,6 +120,9 @@ import {
         return {
           FinInstnId: {
             ClrSysMmbId: {
+              ClrSysId: {
+                Cd: 'USABA',
+              },
               MmbId: (agent as ABAAgent).abaRoutingNumber,
             },
           },

--- a/src/pain/001/rtp-credit-payment-initiation.ts
+++ b/src/pain/001/rtp-credit-payment-initiation.ts
@@ -1,0 +1,239 @@
+import { create } from "xmlbuilder2";
+import { ABAAgent, Account, Agent, BaseAccount, Party, RTPCreditPaymentInstruction } from '../../lib/types';
+import { v4 as uuidv4 } from 'uuid';
+import Dinero, { Currency } from 'dinero.js';
+import { sanitize } from '../../utils/format';
+import { PaymentInitiation } from './iso20022-payment-initiation';
+import { XMLParser } from 'fast-xml-parser';
+import { InvalidXmlError, InvalidXmlNamespaceError } from "../../errors";
+import { parseAccount, parseAgent, parseAmountToMinorUnits } from "../../parseUtils";
+import { Alpha2CountryCode } from "lib/countries";
+
+type AtLeastOne<T> = [T, ...T[]];
+
+/**
+ * Configuration interface for RTP Credit Payment Initiation.
+ * Defines the structure for initiating RTP credit transfers.
+ * @interface RTPCreditPaymentInitiationConfig
+ */
+export interface RTPCreditPaymentInitiationConfig {
+    /** The party initiating the RTP credit transfer. */
+    initiatingParty: Party
+    /** Array containing at least one payment instruction for the RTP credit transfer. */
+    paymentInstructions: AtLeastOne<RTPCreditPaymentInstruction>
+    /** Optional unique identifier for the message. If not provided, a UUID will be generated. */
+    messageId?: string
+    /** Optional creation date for the message. If not provided, current date will be used. */
+    creationDate?: Date
+}
+
+/**
+ * Represents a RTP Credit Payment Initiation.
+ * This class handles the creation and serialization of RTP credit transfer messages
+ * according to the ISO20022 standard.
+ * @class
+ * @extends PaymentInitiation
+ */
+export class RTPCreditPaymentInitiation extends PaymentInitiation {
+    public initiatingParty: Party
+    public paymentInstructions: AtLeastOne<RTPCreditPaymentInstruction>
+    public messageId: string
+    public creationDate: Date
+    public paymentInformationId: string;
+    private paymentSum: string;
+    constructor(config: RTPCreditPaymentInitiationConfig) {
+        super();
+        this.initiatingParty = config.initiatingParty;
+        this.paymentInstructions = config.paymentInstructions;
+        this.messageId = config.messageId || uuidv4().replace(/-/g, '');
+        this.creationDate = config.creationDate || new Date();
+        this.paymentInformationId = sanitize(uuidv4(), 35);
+        this.paymentSum = this.sumPaymentInstructions(this.paymentInstructions as AtLeastOne<RTPCreditPaymentInstruction>);
+        this.validate();
+    }
+    /**
+     * Calculates the sum of all payment instructions.
+     * @private
+     * @param {AtLeastOne<RTPCreditPaymentInstruction>} instructions - Array of payment instructions.
+     * @returns {string} The total sum formatted as a string with 2 decimal places.
+     * @throws {Error} If payment instructions have different currencies.
+     */
+    private sumPaymentInstructions(instructions: AtLeastOne<RTPCreditPaymentInstruction>): string {
+        const instructionDineros = instructions.map(instruction => Dinero({ amount: instruction.amount, currency: instruction.currency }));
+        return instructionDineros.reduce(
+            (acc: Dinero.Dinero, next): Dinero.Dinero => {
+                return acc.add(next as Dinero.Dinero);
+            },
+            Dinero({ amount: 0, currency: instructions[0].currency }),
+        ).toFormat('0.00');
+    }
+
+    /**
+     * Validates the payment initiation data according to SEPA requirements.
+     * @private
+     * @throws {Error} If messageId exceeds 35 characters.
+     * @throws {Error} If payment instructions have different currencies.
+     * @throws {Error} If any creditor has incomplete address information.
+     */
+    private validate() {
+        if (this.messageId.length > 35) {
+            throw new Error('messageId must not exceed 35 characters');
+        }
+    }
+
+    /**
+     * Generates payment information for a single SEPA credit transfer instruction.
+     * @param {RTPCreditPaymentInstruction} instruction - The payment instruction.
+     * @returns {Object} The payment information object formatted according to SEPA specifications.
+     */
+    creditTransfer(instruction: RTPCreditPaymentInstruction) {
+        const paymentInstructionId = sanitize(instruction.id || uuidv4(), 35);
+        const endToEndId = sanitize(instruction.endToEndId || instruction.id || uuidv4(), 35);
+        const dinero = Dinero({ amount: instruction.amount, currency: instruction.currency });
+
+        return {
+            PmtId: {
+                InstrId: paymentInstructionId,
+                EndToEndId: endToEndId,
+            },
+            Amt: {
+                InstdAmt: {
+                    '#': dinero.toFormat('0.00'),
+                    '@Ccy': instruction.currency,
+                },
+            },
+            CdtrAgt: this.agent(instruction.creditor.agent as ABAAgent),
+            Cdtr: this.party(instruction.creditor as Party),
+            CdtrAcct: {
+                Id: {
+                    Othr: {
+                        Id: (instruction.creditor.account as BaseAccount).accountNumber,
+                    },
+                },
+            },
+            RmtInf: instruction.remittanceInformation ? {
+                Ustrd: instruction.remittanceInformation,
+            } : undefined,
+        };
+    }
+
+
+    /**
+     * Serializes the RTP credit transfer initiation to an XML string.
+     * @returns {string} The XML representation of the RTP credit transfer initiation.
+     */
+    public serialize(): string {
+        const xml = {
+            Document: {
+                '@xmlns': 'urn:iso:std:iso:20022:tech:xsd:pain.001.001.03',
+                '@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+                CstmrCdtTrfInitn: {
+                    GrpHdr: {
+                        MsgId: this.messageId,
+                        CreDtTm: this.creationDate.toISOString(),
+                        NbOfTxs: this.paymentInstructions.length.toString(),
+                        CtrlSum: this.paymentSum,
+                        InitgPty: {
+                            Nm: this.initiatingParty.name,
+                            Id: {
+                                OrgId: {
+                                    Othr: {
+                                        Id: this.initiatingParty.id,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    PmtInf: {
+                        PmtInfId: this.paymentInformationId,
+                        PmtMtd: 'TRF',
+                        NbOfTxs: this.paymentInstructions.length.toString(),
+                        CtrlSum: this.paymentSum,
+                        PmtTpInf: {
+                            SvcLvl: { Cd: 'URNS' },
+                            LclInstrm: { Prtry: "RTP" },
+                        },
+                        ReqdExctnDt: this.creationDate.toISOString().split('T').at(0),
+                        Dbtr: this.party(this.initiatingParty),
+                        DbtrAcct: this.account(this.initiatingParty.account as Account),
+                        DbtrAgt: this.agent(this.initiatingParty.agent as Agent),
+                        ChrgBr: 'SLEV',
+                        // payments[]
+                        CdtTrfTxInf: this.paymentInstructions.map(p => this.creditTransfer(p)),
+                    }
+                }
+            },
+        };
+
+        const doc = create(xml);
+        return doc.end({ prettyPrint: true });
+    }
+
+    public static fromXML(rawXml: string): RTPCreditPaymentInitiation {
+        const parser = new XMLParser({ ignoreAttributes: false });
+        const xml = parser.parse(rawXml);
+
+        if (!xml.Document) {
+            throw new InvalidXmlError("Invalid XML format");
+        }
+
+        const namespace = (xml.Document['@_xmlns'] || xml.Document['@_Xmlns']) as string;
+        if (!namespace.startsWith('urn:iso:std:iso:20022:tech:xsd:pain.001.001.03')) {
+            throw new InvalidXmlNamespaceError('Invalid PAIN.001 namespace');
+        }
+
+        const messageId = (xml.Document.CstmrCdtTrfInitn.GrpHdr.MsgId as string);
+        const creationDate = new Date(xml.Document.CstmrCdtTrfInitn.GrpHdr.CreDtTm as string);
+
+        if (Array.isArray(xml.Document.CstmrCdtTrfInitn.PmtInf)) {
+            throw new Error('Multiple PmtInf is not supported');
+        }
+
+        // Assuming we have one PmtInf / one Debtor, we can hack together this information from InitgPty / Dbtr
+        const initiatingParty = {
+            name: (xml.Document.CstmrCdtTrfInitn.GrpHdr.InitgPty.Nm as string) || (xml.Document.CstmrCdtTrfInitn.PmtInf.Dbtr.Nm as string),
+            id: (xml.Document.CstmrCdtTrfInitn.GrpHdr.InitgPty.Id.OrgId?.Othr?.Id) || (xml.Document.CstmrCdtTrfInitn.GrpHdr.InitgPty.Id.OrgId?.BICOrBEI),
+            agent: parseAgent(xml.Document.CstmrCdtTrfInitn.PmtInf.DbtrAgt),
+            account: parseAccount(xml.Document.CstmrCdtTrfInitn.PmtInf.DbtrAcct)
+        }
+
+        const rawInstructions = Array.isArray(xml.Document.CstmrCdtTrfInitn.PmtInf.CdtTrfTxInf) ? xml.Document.CstmrCdtTrfInitn.PmtInf.CdtTrfTxInf : [xml.Document.CstmrCdtTrfInitn.PmtInf.CdtTrfTxInf];
+
+        const paymentInstructions = rawInstructions.map((inst: any) => {
+            const currency = (inst.Amt.InstdAmt['@_Ccy'] as Currency);
+            const amount = parseAmountToMinorUnits(Number(inst.Amt.InstdAmt['#text']), currency);
+            const rawPostalAddress = inst.Cdtr.PstlAdr;
+            return {
+                ...(inst.PmtId.InstrId && { id: (inst.PmtId.InstrId.toString() as string) }),
+                ...(inst.PmtId.EndToEndId && { endToEndId: (inst.PmtId.EndToEndId.toString() as string) }),
+                type: 'sepa',
+                direction: 'credit',
+                amount: amount,
+                currency: currency,
+                creditor: {
+                    name: (inst.Cdtr?.Nm as string),
+                    agent: parseAgent(inst.CdtrAgt),
+                    account: parseAccount(inst.CdtrAcct),
+                    ...((rawPostalAddress && (rawPostalAddress.StreetName || rawPostalAddress.BldgNb || rawPostalAddress.PstlCd || rawPostalAddress.TwnNm || rawPostalAddress.Ctry)) ? {
+                        address: {
+                            ...(rawPostalAddress.StrtNm && { streetName: rawPostalAddress.StrtNm.toString() as string }),
+                            ...(rawPostalAddress.BldgNb && { buildingNumber: rawPostalAddress.BldgNb.toString() as string }),
+                            ...(rawPostalAddress.TwnNm && { townName: rawPostalAddress.TwnNm.toString() as string }),
+                            ...(rawPostalAddress.CtrySubDvsn && { countrySubDivision: rawPostalAddress.CtrySubDvsn.toString() as string }),
+                            ...(rawPostalAddress.PstCd && { postalCode: rawPostalAddress.PstCd.toString() as string }),
+                            ...(rawPostalAddress.Ctry && { country: rawPostalAddress.Ctry as Alpha2CountryCode }),
+                        }
+                    } : {}),
+                },
+                ...(inst.RmtInf?.Ustrd && { remittanceInformation: inst.RmtInf.Ustrd.toString() as string })
+            }
+        }) as AtLeastOne<RTPCreditPaymentInstruction>;
+
+        return new RTPCreditPaymentInitiation({
+            messageId: messageId,
+            creationDate: creationDate,
+            initiatingParty: initiatingParty,
+            paymentInstructions: paymentInstructions
+        });
+    }
+}

--- a/src/pain/001/sepa-credit-payment-initiation.ts
+++ b/src/pain/001/sepa-credit-payment-initiation.ts
@@ -249,7 +249,8 @@ export class SEPACreditPaymentInitiation extends PaymentInitiation {
               ...(rawPostalAddress.Ctry && { country: rawPostalAddress.Ctry as Alpha2CountryCode }),
             }
           } : {}),
-        }
+        },
+        ...(inst.RmtInf?.Ustrd && { remittanceInformation: inst.RmtInf.Ustrd.toString() as string })
       }
     }) as AtLeastOne<SEPACreditPaymentInstruction>;
 

--- a/src/parseUtils.ts
+++ b/src/parseUtils.ts
@@ -26,7 +26,7 @@ export const parseAgent = (agent: any): Agent => {
   }
 
   return {
-    abaRoutingNumber: agent.FinInstnId.Othr.Id,
+    abaRoutingNumber: (agent.FinInstnId.Othr?.Id || agent.FinInstnId.ClrSysMmbId.MmbId).toString(),
   } as Agent;
 };
 

--- a/test/assets/cross_river/pain_001_rtp_credit.xml
+++ b/test/assets/cross_river/pain_001_rtp_credit.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.001.03">
+    <CstmrCdtTrfInitn>
+        <GrpHdr>
+            <MsgId>DOMT11234562</MsgId>
+            <CreDtTm>2020-06-29T10:24:09</CreDtTm>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>0.01</CtrlSum>
+            <InitgPty>
+                <Nm>John Doe Corporation</Nm>
+                <Id>
+                    <OrgId>
+                        <BICOrBEI>JOHNDOE99</BICOrBEI>
+                    </OrgId>
+                </Id>
+            </InitgPty>
+        </GrpHdr>
+        <PmtInf>
+            <PmtInfId>DOMT12345678</PmtInfId>
+            <PmtMtd>TRF</PmtMtd>
+            <BtchBookg>false</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>0.01</CtrlSum>
+            <PmtTpInf>
+                <InstrPrty>NORM</InstrPrty>
+                <SvcLvl>
+                    <Cd>URNS</Cd>
+                </SvcLvl>
+                 <LclInstrm>    
+                    <Prtry>RTP</Prtry>    
+                </LclInstrm>
+            </PmtTpInf>
+            <ReqdExctnDt>2020-06-29</ReqdExctnDt>
+            <Dbtr>
+                <Nm>John Doe Corporation</Nm>
+                <PstlAdr>
+                    <StrtNm>999 Battery Street, 13th Floor</StrtNm>
+                    <PstCd>99999</PstCd>
+                    <TwnNm>Anytown</TwnNm>
+                    <CtrySubDvsn>CA</CtrySubDvsn>
+                    <Ctry>US</Ctry>
+                </PstlAdr>
+            </Dbtr>
+            <DbtrAcct>
+                <Id>
+                    <Othr>
+                        <Id>1123456789</Id>
+                    </Othr>
+                </Id>
+                <Ccy>USD</Ccy>
+            </DbtrAcct>
+            <DbtrAgt>
+                <FinInstnId>
+                    <ClrSysMmbId>
+                        <ClrSysId>
+                            <Cd>USABA</Cd>
+                        </ClrSysId>
+                        <MmbId>123456789</MmbId>
+                    </ClrSysMmbId>
+                    <PstlAdr>
+                        <Ctry>US</Ctry>
+                    </PstlAdr>
+                </FinInstnId>
+            </DbtrAgt>
+            <ChrgBr>SHAR</ChrgBr>
+            <CdtTrfTxInf>
+                <PmtId>
+                    <InstrId>234ACHC123455</InstrId>
+                    <EndToEndId>1000000000000011</EndToEndId>
+                </PmtId>
+                <Amt>
+                    <InstdAmt Ccy="USD">0.01</InstdAmt>
+                </Amt>
+                <CdtrAgt>
+                    <FinInstnId>
+                        <ClrSysMmbId>
+                            <ClrSysId>
+                                <Cd>USABA</Cd>
+                            </ClrSysId>
+                            <MmbId>123456789</MmbId>
+                        </ClrSysMmbId>
+                        <Nm>Cross River Bank NJ</Nm>
+                        <PstlAdr>
+                            <Ctry>US</Ctry>
+                        </PstlAdr>
+                    </FinInstnId>
+                </CdtrAgt>
+                <Cdtr>
+                    <Nm>John Doe Funding LLC</Nm>
+                    <PstlAdr>
+                        <StrtNm>999 Any Avenue</StrtNm>
+                        <PstCd>10000</PstCd>
+                        <TwnNm>New York</TwnNm>
+                        <CtrySubDvsn>NY</CtrySubDvsn>
+                        <Ctry>US</Ctry>
+                    </PstlAdr>
+                </Cdtr>
+                <CdtrAcct>
+                    <Id>
+                        <Othr>
+                            <Id>1123456789</Id>
+                        </Othr>
+                    </Id>
+                    <Tp>
+                        <Cd>CACC</Cd>
+                    </Tp>
+                    <Ccy>USD</Ccy>
+                </CdtrAcct>
+                <RmtInf>
+                    <Ustrd>Testing</Ustrd>
+                </RmtInf>
+            </CdtTrfTxInf>
+        </PmtInf>
+    </CstmrCdtTrfInitn>
+</Document>

--- a/test/pain/001/rtp-credit-payment-initiation.test.ts
+++ b/test/pain/001/rtp-credit-payment-initiation.test.ts
@@ -1,0 +1,295 @@
+import { RTPCreditPaymentInitiation, RTPCreditPaymentInitiationConfig } from "../../../src/pain/001/rtp-credit-payment-initiation";
+import libxmljs from 'libxmljs';
+import fs from 'fs';
+import { Alpha2CountryCode } from "lib/countries";
+import ISO20022 from '../../../src/iso20022';
+import { v4 as uuidv4 } from 'uuid';
+import { ABAAgent, BaseAccount } from "index";
+
+describe('RTPCreditPaymentInitiation', () => {
+    let rtpPaymentInitiationConfig: RTPCreditPaymentInitiationConfig;
+    let rtpPayment: RTPCreditPaymentInitiation;
+    const initiatingParty = {
+        name: "Acme Corp",
+        id: "ACMECORP",
+        account: {
+            accountNumber: "123456789012",
+        },
+        agent: {
+            abaRoutingNumber: "111000025",
+        }
+    }
+
+    const paymentInstruction1 = {
+        id: "abcdefg",
+        endToEndId: "123456789",
+        type: 'rtp' as const,
+        currency: "USD" as const,
+        direction: "credit" as const,
+        creditor: {
+            name: "John Doe",
+            account: {
+                accountNumber: "987654321",
+            },
+            agent: {
+                abaRoutingNumber: "121000248"
+            },
+            address: {
+                streetName: "Main Street",
+                buildingNumber: "123",
+                townName: "San Francisco",
+                countrySubDivision: "CA",
+                postalCode: "94105",
+                country: "US" as Alpha2CountryCode
+            }
+        },
+        amount: 1500,
+        remittanceInformation: "Invoice #12345"
+    }
+
+    const paymentInstruction2 = {
+        id: "hijklmn",
+        endToEndId: "987654321",
+        type: 'rtp' as const,
+        direction: "credit" as const,
+        creditor: {
+            name: "Jane Smith",
+            account: {
+                accountNumber: "456789123",
+            },
+            agent: {
+                abaRoutingNumber: "026009593"
+            },
+            address: {
+                streetName: "Broadway",
+                buildingNumber: "456",
+                townName: "New York",
+                countrySubDivision: "NY",
+                postalCode: "10018",
+                country: "US" as Alpha2CountryCode
+            }
+        },
+        amount: 2500,
+        currency: "USD" as const,
+        remittanceInformation: "Invoice #67890"
+    }
+
+    describe('serialize', () => {
+        beforeEach(() => {
+            rtpPaymentInitiationConfig = {
+                initiatingParty,
+                paymentInstructions: [
+                    paymentInstruction1,
+                    {
+                        type: 'rtp',
+                        direction: "credit",
+                        creditor: {
+                            name: "Sarah Johnson",
+                            account: {
+                                accountNumber: "123456789012",
+                            },
+                            agent: {
+                                abaRoutingNumber: "072000326"
+                            },
+                            address: {
+                                streetName: "Park Avenue",
+                                buildingNumber: "789",
+                                townName: "New York",
+                                countrySubDivision: "NY",
+                                postalCode: "10022",
+                                country: "US"
+                            }
+                        },
+                        amount: 3500,
+                        currency: "USD"
+                    }
+                ]
+            }
+        })
+
+        test('should create a RTPCreditPaymentInitiation instance', () => {
+            rtpPayment = new RTPCreditPaymentInitiation(rtpPaymentInitiationConfig)
+            expect(rtpPayment).toBeInstanceOf(RTPCreditPaymentInitiation);
+        });
+
+        test('should serialize to XML', () => {
+            rtpPayment = new RTPCreditPaymentInitiation(rtpPaymentInitiationConfig)
+            const xml = rtpPayment.serialize();
+            expect(xml).toContain('<Document');
+            // Add more specific XML checks
+            expect(xml).toContain('xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.001.03"');
+            // Use regex to match the XML pattern regardless of newlines
+            expect(xml).toMatch(/<LclInstrm>\s*<Prtry>\s*RTP\s*<\/Prtry>\s*<\/LclInstrm>/);
+        });
+
+        test('should validate against XSD', () => {
+            rtpPayment = new RTPCreditPaymentInitiation(rtpPaymentInitiationConfig)
+            const xml = rtpPayment.serialize();
+            const xsdSchema = fs.readFileSync(
+                `${process.cwd()}/schemas/pain/pain.001.001.03.xsd`,
+                'utf8',
+            );
+            const xmlDoc = libxmljs.parseXml(xml);
+            const xsdDoc = libxmljs.parseXml(xsdSchema);
+            const isValid = xmlDoc.validate(xsdDoc);
+            expect(isValid).toBeTruthy();
+        });
+
+        describe('created with iso20022', () => {
+            let iso20022 = new ISO20022({
+                initiatingParty: initiatingParty
+            })
+
+            test('should create a RTPCreditPaymentInitiation instance', () => {
+                let rtpPayment = iso20022.createRTPCreditPaymentInitiation([paymentInstruction1]);
+                const xml = rtpPayment.serialize();
+                const xsdSchema = fs.readFileSync(
+                    `${process.cwd()}/schemas/pain/pain.001.001.03.xsd`,
+                    'utf8',
+                );
+                const xmlDoc = libxmljs.parseXml(xml);
+                const xsdDoc = libxmljs.parseXml(xsdSchema);
+                const isValid = xmlDoc.validate(xsdDoc);
+                expect(isValid).toBeTruthy();
+            })
+        })
+    })
+
+    describe('fromXML', () => {
+        describe('with Cross River 001 XML file', () => {
+            let xmlContent: string;
+            let rtpPayment: RTPCreditPaymentInitiation;
+
+            beforeEach(() => {
+                // Read the Cross River XML file
+                xmlContent = fs.readFileSync(
+                    `${process.cwd()}/test/assets/cross_river/pain_001_rtp_credit.xml`,
+                    'utf8',
+                );
+                rtpPayment = RTPCreditPaymentInitiation.fromXML(xmlContent);
+            });
+
+            test('should create a RTPCreditPaymentInitiation instance', () => {
+                expect(rtpPayment).toBeInstanceOf(RTPCreditPaymentInitiation);
+            });
+
+            test('should correctly parse message metadata', () => {
+                expect(rtpPayment.messageId).toBe('DOMT11234562');
+                expect(rtpPayment.creationDate).toStrictEqual(new Date('2020-06-29T10:24:09'));
+            });
+
+            test('should correctly parse initiating party information', () => {
+                expect(rtpPayment.initiatingParty.name).toBe('John Doe Corporation');
+                expect(rtpPayment.initiatingParty.id).toBe('JOHNDOE99');
+
+                // Check account information
+                expect(rtpPayment.initiatingParty.account).toBeDefined();
+                expect((rtpPayment.initiatingParty.account as BaseAccount).accountNumber).toBe('1123456789');
+
+                // Check agent (bank) information
+                expect(rtpPayment.initiatingParty.agent).toBeDefined();
+                expect((rtpPayment.initiatingParty.agent as ABAAgent).abaRoutingNumber).toBe('123456789');
+            });
+
+            test('should correctly parse payment instruction', () => {
+                expect(rtpPayment.paymentInstructions).toHaveLength(1);
+
+                const instruction = rtpPayment.paymentInstructions[0];
+                expect(instruction.id).toBe('234ACHC123455');
+                expect(instruction.endToEndId).toBe('1000000000000011');
+                expect(instruction.amount).toBe(1); // 0.01 USD in minor units
+                expect(instruction.currency).toBe('USD');
+                expect(instruction.remittanceInformation).toBe('Testing');
+
+                // Check creditor information
+                expect(instruction.creditor.name).toBe('John Doe Funding LLC');
+                expect((instruction.creditor.account as BaseAccount).accountNumber).toBe('1123456789');
+                expect((instruction.creditor.agent as ABAAgent).abaRoutingNumber).toBe('123456789');
+
+                // Check address information
+                expect(instruction.creditor.address).toBeDefined();
+                expect(instruction.creditor.address?.streetName).toBe('999 Any Avenue');
+                expect(instruction.creditor.address?.postalCode).toBe('10000');
+                expect(instruction.creditor.address?.townName).toBe('New York');
+                expect(instruction.creditor.address?.countrySubDivision).toBe('NY');
+                expect(instruction.creditor.address?.country).toBe('US');
+            });
+        })
+        describe('with generated RTP 001 XML file', () => {
+            // Create a test instance and serialize to XML
+            const messageId = uuidv4().slice(0, 35);
+            const creationDate = new Date();
+            const rtpPayment = new RTPCreditPaymentInitiation({
+                messageId: messageId,
+                creationDate: creationDate,
+                initiatingParty: initiatingParty,
+                paymentInstructions: [paymentInstruction1, paymentInstruction2]
+            });
+            const serializedXml = rtpPayment.serialize();
+
+            // Now parse it back using fromXML
+            const recreatedRtpPayment = RTPCreditPaymentInitiation.fromXML(serializedXml);
+
+            test('should create a RTPCreditPaymentInitiation instance', () => {
+                expect(recreatedRtpPayment).toBeInstanceOf(RTPCreditPaymentInitiation);
+            });
+
+            test('information should be correctly parsed', () => {
+                expect(recreatedRtpPayment.messageId).toBe(messageId);
+                expect(recreatedRtpPayment.creationDate).toStrictEqual(creationDate);
+                expect(recreatedRtpPayment.initiatingParty.name).toBe(initiatingParty.name);
+                expect(recreatedRtpPayment.initiatingParty.id).toBe(initiatingParty.id);
+
+                // Test payment instructions are correctly parsed
+                expect(recreatedRtpPayment.paymentInstructions).toHaveLength(2);
+
+                // Verify the first payment instruction
+                const parsedInstruction1 = recreatedRtpPayment.paymentInstructions[0];
+                expect(parsedInstruction1.id).toBe(paymentInstruction1.id);
+                expect(parsedInstruction1.endToEndId).toBe(paymentInstruction1.endToEndId);
+                expect(parsedInstruction1.amount).toBe(paymentInstruction1.amount);
+                expect(parsedInstruction1.currency).toBe(paymentInstruction1.currency);
+                expect(parsedInstruction1.creditor.name).toBe(paymentInstruction1.creditor.name);
+                expect(parsedInstruction1.remittanceInformation).toBe(paymentInstruction1.remittanceInformation);
+
+                // Verify the second payment instruction
+                const parsedInstruction2 = recreatedRtpPayment.paymentInstructions[1];
+                expect(parsedInstruction2.id).toBe(paymentInstruction2.id);
+                expect(parsedInstruction2.endToEndId).toBe(paymentInstruction2.endToEndId);
+                expect(parsedInstruction2.amount).toBe(paymentInstruction2.amount);
+            });
+        });
+
+        describe('with a multiple pmtinf RTP 001 XML file', () => {
+            // Create a sample with multiple payment info blocks to test error handling
+            // This would need a sample XML file with multiple PmtInf blocks
+            test('should throw an error for multiple payment information blocks', () => {
+                const xmlWithMultiplePmtInf = `<?xml version="1.0" encoding="UTF-8"?>
+                <Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.001.03" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <CstmrCdtTrfInitn>
+                        <GrpHdr>
+                            <MsgId>test-message-id</MsgId>
+                            <CreDtTm>2025-02-26T11:00:00</CreDtTm>
+                            <NbOfTxs>2</NbOfTxs>
+                            <CtrlSum>50.00</CtrlSum>
+                            <InitgPty>
+                                <Nm>Acme Corp</Nm>
+                                <Id><OrgId><Othr><Id>ACMECORP</Id></Othr></OrgId></Id>
+                            </InitgPty>
+                        </GrpHdr>
+                        <PmtInf>
+                            <!-- First payment info block -->
+                        </PmtInf>
+                        <PmtInf>
+                            <!-- Second payment info block -->
+                        </PmtInf>
+                    </CstmrCdtTrfInitn>
+                </Document>`;
+
+                expect(() => {
+                    RTPCreditPaymentInitiation.fromXML(xmlWithMultiplePmtInf);
+                }).toThrow('Multiple PmtInf is not supported');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Implemented RTP Credit.

Tested ingestion against Cross Borders RTP Rail / against file creation!

```
// Create an RTP ISO20022 Message using iso20022.js
const payment = checking.createRTPCreditPaymentInitiation([
    {
        type: 'rtp',
        direction: 'credit',
        amount: 100000, // $1000.00
        currency: 'USD',
        creditor: {
            name: 'All-American Dogs Co.',
            account: {
                accountNumber: '123456789012',
            },
            agent: {
                abaRoutingNumber: '37714568112',
            }
        },
        remittanceInformation: '1000 Hot Dogs Feb26',
    }
]);

// Send using fiatwebservices.com
client.payment_transfers.send(payment)
``` 