### PR TITLE
Full Deprecate xmlbuilder2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "dinero.js": "^1.9.1",
         "fast-xml-parser": "^4.4.1",
-        "uuid": "^10.0.0",
-        "xmlbuilder2": "^3.1.1"
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.24.7",
@@ -1683,54 +1682,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@oozcitak/dom": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
-      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/url": "1.0.4",
-        "@oozcitak/util": "8.3.8"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/@oozcitak/infra": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
-      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/util": "8.3.8"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/@oozcitak/url": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
-      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/util": "8.3.8"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/@oozcitak/util": {
-      "version": "8.3.8",
-      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
-      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2412,6 +2363,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -3403,6 +3355,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -6066,6 +6019,7 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -7547,6 +7501,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
@@ -8448,21 +8403,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/xmlbuilder2": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.1.1.tgz",
-      "integrity": "sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==",
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/dom": "1.15.10",
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/util": "8.3.8",
-        "js-yaml": "3.14.1"
-      },
-      "engines": {
-        "node": ">=12.0"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
   "dependencies": {
     "dinero.js": "^1.9.1",
     "fast-xml-parser": "^4.4.1",
-    "uuid": "^10.0.0",
-    "xmlbuilder2": "^3.1.1"
+    "uuid": "^10.0.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ export default defineConfig([
       nodeResolve(),
       commonjs(),
     ],
-    external: ['dinero.js', 'xmlbuilder2'], // Add any external dependencies here
+    external: ['dinero.js'], // Add any external dependencies here
   },
   {
     input: 'src/index.ts',

--- a/src/pain/001/iso20022-payment-initiation.ts
+++ b/src/pain/001/iso20022-payment-initiation.ts
@@ -1,3 +1,4 @@
+import { XMLBuilder } from 'fast-xml-parser';
 import {
     Party,
     IBANAccount,
@@ -136,5 +137,14 @@ import {
      */
     toString() {
       return this.serialize();
+    }
+
+    static getBuilder(): XMLBuilder {
+      return new XMLBuilder({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@',
+        textNodeName: '#',
+        format: true,
+      });
     }
   }

--- a/src/pain/001/rtp-credit-payment-initiation.ts
+++ b/src/pain/001/rtp-credit-payment-initiation.ts
@@ -122,12 +122,7 @@ export class RTPCreditPaymentInitiation extends PaymentInitiation {
      * @returns {string} The XML representation of the RTP credit transfer initiation.
      */
     public serialize(): string {
-        const builder = new XMLBuilder({
-            ignoreAttributes: false,
-            attributeNamePrefix: '@',
-            textNodeName: '#',
-            format: true,
-        });
+        const builder = PaymentInitiation.getBuilder();
         const xml = {
             '?xml': {
                 '@version': '1.0',

--- a/src/pain/001/rtp-credit-payment-initiation.ts
+++ b/src/pain/001/rtp-credit-payment-initiation.ts
@@ -1,10 +1,9 @@
-import { create } from "xmlbuilder2";
 import { ABAAgent, Account, Agent, BaseAccount, Party, RTPCreditPaymentInstruction } from '../../lib/types';
 import { v4 as uuidv4 } from 'uuid';
 import Dinero, { Currency } from 'dinero.js';
 import { sanitize } from '../../utils/format';
 import { PaymentInitiation } from './iso20022-payment-initiation';
-import { XMLParser } from 'fast-xml-parser';
+import { XMLBuilder, XMLParser } from 'fast-xml-parser';
 import { InvalidXmlError, InvalidXmlNamespaceError } from "../../errors";
 import { parseAccount, parseAgent, parseAmountToMinorUnits } from "../../parseUtils";
 import { Alpha2CountryCode } from "lib/countries";
@@ -40,7 +39,7 @@ export class RTPCreditPaymentInitiation extends PaymentInitiation {
     public messageId: string
     public creationDate: Date
     public paymentInformationId: string;
-    private paymentSum: string;
+    private formattedPaymentSum: string;
     constructor(config: RTPCreditPaymentInitiationConfig) {
         super();
         this.initiatingParty = config.initiatingParty;
@@ -48,7 +47,7 @@ export class RTPCreditPaymentInitiation extends PaymentInitiation {
         this.messageId = config.messageId || uuidv4().replace(/-/g, '');
         this.creationDate = config.creationDate || new Date();
         this.paymentInformationId = sanitize(uuidv4(), 35);
-        this.paymentSum = this.sumPaymentInstructions(this.paymentInstructions as AtLeastOne<RTPCreditPaymentInstruction>);
+        this.formattedPaymentSum = this.sumPaymentInstructions(this.paymentInstructions as AtLeastOne<RTPCreditPaymentInstruction>);
         this.validate();
     }
     /**
@@ -123,7 +122,17 @@ export class RTPCreditPaymentInitiation extends PaymentInitiation {
      * @returns {string} The XML representation of the RTP credit transfer initiation.
      */
     public serialize(): string {
+        const builder = new XMLBuilder({
+            ignoreAttributes: false,
+            attributeNamePrefix: '@',
+            textNodeName: '#',
+            format: true,
+        });
         const xml = {
+            '?xml': {
+                '@version': '1.0',
+                '@encoding': 'UTF-8'
+            },
             Document: {
                 '@xmlns': 'urn:iso:std:iso:20022:tech:xsd:pain.001.001.03',
                 '@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
@@ -132,7 +141,7 @@ export class RTPCreditPaymentInitiation extends PaymentInitiation {
                         MsgId: this.messageId,
                         CreDtTm: this.creationDate.toISOString(),
                         NbOfTxs: this.paymentInstructions.length.toString(),
-                        CtrlSum: this.paymentSum,
+                        CtrlSum: this.formattedPaymentSum,
                         InitgPty: {
                             Nm: this.initiatingParty.name,
                             Id: {
@@ -148,7 +157,7 @@ export class RTPCreditPaymentInitiation extends PaymentInitiation {
                         PmtInfId: this.paymentInformationId,
                         PmtMtd: 'TRF',
                         NbOfTxs: this.paymentInstructions.length.toString(),
-                        CtrlSum: this.paymentSum,
+                        CtrlSum: this.formattedPaymentSum,
                         PmtTpInf: {
                             SvcLvl: { Cd: 'URNS' },
                             LclInstrm: { Prtry: "RTP" },
@@ -165,8 +174,7 @@ export class RTPCreditPaymentInitiation extends PaymentInitiation {
             },
         };
 
-        const doc = create(xml);
-        return doc.end({ prettyPrint: true });
+        return builder.build(xml);
     }
 
     public static fromXML(rawXml: string): RTPCreditPaymentInitiation {

--- a/src/pain/001/sepa-credit-payment-initiation.ts
+++ b/src/pain/001/sepa-credit-payment-initiation.ts
@@ -145,12 +145,7 @@ export class SEPACreditPaymentInitiation extends PaymentInitiation {
    * @returns {string} The XML representation of the SEPA credit transfer initiation.
    */
   public serialize(): string {
-    const builder = new XMLBuilder({
-      ignoreAttributes: false,
-      attributeNamePrefix: '@',
-      textNodeName: '#',
-      format: true,
-    });
+    const builder = PaymentInitiation.getBuilder();
     const xml = {
       '?xml': {
         '@version': '1.0',

--- a/src/pain/001/swift-credit-payment-initiation.ts
+++ b/src/pain/001/swift-credit-payment-initiation.ts
@@ -204,12 +204,7 @@ export class SWIFTCreditPaymentInitiation extends PaymentInitiation {
   }
 
   public serialize(): string {
-    const builder = new XMLBuilder({
-      ignoreAttributes: false,
-      attributeNamePrefix: '@',
-      textNodeName: '#',
-      format: true,
-    });
+    const builder = PaymentInitiation.getBuilder();
     const xml = {
       '?xml': {
         '@version': '1.0',

--- a/test/pain/001/sepa-credit-payment-initiation.test.ts
+++ b/test/pain/001/sepa-credit-payment-initiation.test.ts
@@ -1,10 +1,10 @@
-import { SEPACreditPaymentInitiation, SEPACreditPaymentInitiationConfig } from "../../../src/pain/001/sepa-credit-payment-initiation";
-import { SEPACreditPaymentInstruction, ExternalCategoryPurposeCode } from "../../../src/lib/types";
-import libxmljs from 'libxmljs';
 import fs from 'fs';
 import { Alpha2CountryCode } from "lib/countries";
-import ISO20022 from '../../../src/iso20022';
+import libxmljs from 'libxmljs';
 import { v4 as uuidv4 } from 'uuid';
+import ISO20022 from '../../../src/iso20022';
+import { ExternalCategoryPurposeCode } from "../../../src/lib/types";
+import { SEPACreditPaymentInitiation, SEPACreditPaymentInitiationConfig } from "../../../src/pain/001/sepa-credit-payment-initiation";
 
 type AtLeastOne<T> = [T, ...T[]];
 


### PR DESCRIPTION
xmlbuilder2 has an issue which prevents this module from running in certain javascript runtimes entirely.

https://github.com/oozcitak/xmlbuilder2/issues/149#issuecomment-1634955124

We can accomplish the same using the `fast-xml-parser` we already have. We have tested that this works on more runtimes.

Importantly, this brings our production dependencies from 4 to 3. PS. in the future we can remove uuid aswell when we tackle #28 