### PR TITLE
Make ISO20022 create methods take configurations

### DIFF
--- a/examples/rtp-credit-transfer.ts
+++ b/examples/rtp-credit-transfer.ts
@@ -16,24 +16,29 @@ async function main() {
         },
     });
 
-    const payment = iso20022.createRTPCreditPaymentInitiation([
-        {
-            type: 'rtp',
-            direction: 'credit',
-            amount: 100000, // $1000.00
-            currency: 'USD',
-            creditor: {
-                name: 'All-American Dogs Co.',
-                account: {
-                    accountNumber: '123456789012',
+    const payment = iso20022.createRTPCreditPaymentInitiation({
+        paymentInstructions: [
+            {
+                type: 'rtp',
+                direction: 'credit',
+                amount: 100000, // $1000.00
+                currency: 'USD',
+                creditor: {
+                    name: 'All-American Dogs Co.',
+                    account: {
+                        accountNumber: '123456789012',
+                    },
+                    agent: {
+                        abaRoutingNumber: '37714568112',
+                    }
                 },
-                agent: {
-                    abaRoutingNumber: '37714568112',
-                }
-            },
-            remittanceInformation: '1000 Hot Dogs Feb26',
-        }
-    ]);
+                remittanceInformation: '1000 Hot Dogs Feb26',
+            }
+        ],
+        // Optional fields
+        messageId: 'RTP-TRANSFER-001',
+        creationDate: new Date('2025-03-04'),
+    });
 
     console.log(payment.serialize());
 }

--- a/examples/sepa-credit-transfer.ts
+++ b/examples/sepa-credit-transfer.ts
@@ -19,31 +19,36 @@ async function main() {
         },
     });
 
-    const payment = iso20022.createSEPACreditPaymentInitiation([
-        {
-            type: 'sepa',
-            direction: 'credit',
-            creditor: {
-                name: 'Dáel Muñiz',
-                account: {
-                    iban: 'ES8201822200150201504058'
+    const payment = iso20022.createSEPACreditPaymentInitiation({
+        paymentInstructions: [
+            {
+                type: 'sepa',
+                direction: 'credit',
+                creditor: {
+                    name: 'Dáel Muñiz',
+                    account: {
+                        iban: 'ES8201822200150201504058'
+                    },
+                    agent: {
+                        bic: 'BBVAESMMXXX'
+                    },
+                    address: {
+                        streetName: 'Calle de Serrano',
+                        buildingNumber: '41',
+                        townName: 'Madrid',
+                        countrySubDivision: 'Madrid',
+                        postalCode: '28001',
+                        country: 'ES'
+                    }
                 },
-                agent: {
-                    bic: 'BBVAESMMXXX'
-                },
-                address: {
-                    streetName: 'Calle de Serrano',
-                    buildingNumber: '41',
-                    townName: 'Madrid',
-                    countrySubDivision: 'Madrid',
-                    postalCode: '28001',
-                    country: 'ES'
-                }
-            },
-            amount: 1000,
-            currency: 'EUR'
-        }
-    ]);
+                amount: 1000,
+                currency: 'EUR'
+            }
+        ],
+        // Optional fields
+        messageId: 'SEPA-TRANSFER-001',
+        creationDate: new Date('2025-03-04'),
+    });
 
     console.log(payment.serialize())
 }

--- a/examples/swift-credit-transfer.ts
+++ b/examples/swift-credit-transfer.ts
@@ -20,8 +20,8 @@ async function main() {
     });
 
     // Create a SWIFT credit transfer to a German creditor
-    const payment = iso20022.createSWIFTCreditPaymentInitiation(
-        [
+    const payment = iso20022.createSWIFTCreditPaymentInitiation({
+        paymentInstructions: [
             {
                 type: 'swift',
                 direction: 'credit',
@@ -49,7 +49,10 @@ async function main() {
                 remittanceInformation: 'Invoice payment #123',
             },
         ],
-    );
+        // Optional fields
+        messageId: 'SWIFT-TRANSFER-001',
+        creationDate: new Date('2025-03-04'),
+    });
 
     const xml = await payment.serialize();
     console.log(xml);

--- a/src/iso20022.ts
+++ b/src/iso20022.ts
@@ -35,6 +35,154 @@ export interface ISO20022Config {
 }
 
 /**
+ * Configuration interface for SWIFT Credit Payment Initiation.
+ * @interface SWIFTCreditPaymentInitiationConfig
+ * @example
+ * const config: SWIFTCreditPaymentInitiationConfig = {
+ *     paymentInstructions: [
+ *       {
+ *         type: 'swift',
+ *         direction: 'credit',
+ *         amount: 1000,
+ *         currency: 'USD',
+ *         creditor: {
+ *           name: 'Hans Schneider',
+ *           account: {
+ *             iban: 'DE1234567890123456',
+ *           },
+ *           agent: {
+ *             bic: 'DEUTDEFF',
+ *             bankAddress: {
+ *               country: 'DE',
+ *             },
+ *           },
+ *           address: {
+ *             streetName: 'Hauptstraße',
+ *             buildingNumber: '42',
+ *             postalCode: '10115',
+ *             townName: 'Berlin',
+ *             country: 'DE',
+ *           },
+ *         },
+ *         remittanceInformation: 'Invoice payment #123',
+ *       },
+ *     ],
+ *     messageId: 'MSGID123', // Optional
+ *     creationDate: new Date(), // Optional
+ * };
+ */
+export interface SWIFTCreditPaymentInitiationConfig {
+  /**
+   * An array of payment instructions.
+   * @type {AtLeastOne<SWIFTCreditPaymentInstruction>}
+   */
+  paymentInstructions: AtLeastOne<SWIFTCreditPaymentInstruction>;
+  
+  /**
+   * Optional unique identifier for the message. If not provided, a UUID will be generated.
+   * @type {string}
+   */
+  messageId?: string;
+  
+  /**
+   * Optional creation date for the message. If not provided, current date will be used.
+   * @type {Date}
+   */
+  creationDate?: Date;
+}
+
+/**
+ * Configuration interface for SEPA Credit Payment Initiation.
+ * @interface SEPACreditPaymentInitiationConfig
+ * @example
+ * const config: SEPACreditPaymentInitiationConfig = {
+ *     paymentInstructions: [
+ *       {
+ *         type: 'sepa',
+ *         direction: 'credit',
+ *         amount: 1000, // €10.00 Euros
+ *         currency: 'EUR',
+ *         creditor: {
+ *           name: 'Hans Schneider',
+ *           account: {
+ *             iban: 'DE1234567890123456',
+ *           },
+ *         },
+ *         remittanceInformation: 'Invoice payment #123',
+ *       },
+ *     ],
+ *     messageId: 'MSGID123', // Optional
+ *     creationDate: new Date(), // Optional
+ * };
+ */
+export interface SEPACreditPaymentInitiationConfig {
+  /**
+   * An array of payment instructions.
+   * @type {AtLeastOne<SEPACreditPaymentInstruction>}
+   */
+  paymentInstructions: AtLeastOne<SEPACreditPaymentInstruction>;
+  
+  /**
+   * Optional unique identifier for the message. If not provided, a UUID will be generated.
+   * @type {string}
+   */
+  messageId?: string;
+  
+  /**
+   * Optional creation date for the message. If not provided, current date will be used.
+   * @type {Date}
+   */
+  creationDate?: Date;
+}
+
+/**
+ * Configuration interface for RTP Credit Payment Initiation.
+ * @interface RTPCreditPaymentInitiationConfig
+ * @example
+ * const config: RTPCreditPaymentInitiationConfig = {
+ *     paymentInstructions: [
+ *       {
+ *         type: 'rtp',
+ *         direction: 'credit',
+ *         amount: 100000, // $1000.00
+ *         currency: 'USD',
+ *         creditor: {
+ *           name: 'All-American Dogs Co.',
+ *           account: {
+ *             accountNumber: '123456789012',
+ *           },
+ *           agent: {
+ *             abaRoutingNumber: '37714568112',
+ *           },
+ *         },
+ *         remittanceInformation: '1000 Hot Dogs Feb26',
+ *       },
+ *     ],
+ *     messageId: 'MSGID123', // Optional
+ *     creationDate: new Date(), // Optional
+ * };
+ */
+export interface RTPCreditPaymentInitiationConfig {
+  /**
+   * An array of payment instructions.
+   * @type {AtLeastOne<RTPCreditPaymentInstruction>}
+   */
+  paymentInstructions: AtLeastOne<RTPCreditPaymentInstruction>;
+  
+  /**
+   * Optional unique identifier for the message. If not provided, a UUID will be generated.
+   * @type {string}
+   */
+  messageId?: string;
+  
+  /**
+   * Optional creation date for the message. If not provided, current date will be used.
+   * @type {Date}
+   */
+  creationDate?: Date;
+}
+
+/**
  * Represents an ISO20022 core message creator.
  * This class provides methods to create various basic ISO20022 compliant messages.
  *
@@ -68,107 +216,125 @@ class ISO20022 {
 
   /**
    * Creates a SWIFT Credit Payment Initiation message.
-   * @param {SWIFTCreditPaymentInstruction[]} paymentInstructions - An array of payment instructions.
+   * @param {SWIFTCreditPaymentInitiationConfig} config - Configuration containing payment instructions and optional parameters.
    * @example
-   * const payment = iso20022.createSWIFTCreditPaymentInitiation([
-   *   {
-   *     type: 'swift',
-   *     direction: 'credit',
-   *     amount: 1000,
-   *     currency: 'USD',
-   *     creditor: {
-   *       name: 'Hans Schneider',
-   *       account: {
-   *         iban: 'DE1234567890123456',
-   *       },
-   *       agent: {
-   *         bic: 'DEUTDEFF',
-   *         bankAddress: {
+   * const payment = iso20022.createSWIFTCreditPaymentInitiation({
+   *   paymentInstructions: [
+   *     {
+   *       type: 'swift',
+   *       direction: 'credit',
+   *       amount: 1000,
+   *       currency: 'USD',
+   *       creditor: {
+   *         name: 'Hans Schneider',
+   *         account: {
+   *           iban: 'DE1234567890123456',
+   *         },
+   *         agent: {
+   *           bic: 'DEUTDEFF',
+   *           bankAddress: {
+   *             country: 'DE',
+   *           },
+   *         },
+   *         address: {
+   *           streetName: 'Hauptstraße',
+   *           buildingNumber: '42',
+   *           postalCode: '10115',
+   *           townName: 'Berlin',
    *           country: 'DE',
    *         },
    *       },
-   *       address: {
-   *         streetName: 'Hauptstraße',
-   *         buildingNumber: '42',
-   *         postalCode: '10115',
-   *         townName: 'Berlin',
-   *         country: 'DE',
-   *       },
+   *       remittanceInformation: 'Invoice payment #123',
    *     },
-   *     remittanceInformation: 'Invoice payment #123',
-   *   },
-   * ]);
+   *   ],
+   *   messageId: 'SWIFT-MSG-001', // Optional
+   *   creationDate: new Date('2025-03-01'), // Optional
+   * });
    * @returns {SWIFTCreditPaymentInitiation} A new SWIFT Credit Payment Initiation object.
    */
   createSWIFTCreditPaymentInitiation(
-    paymentInstructions: AtLeastOne<SWIFTCreditPaymentInstruction>,
+    config: SWIFTCreditPaymentInitiationConfig,
   ) {
     return new SWIFTCreditPaymentInitiation({
       initiatingParty: this.initiatingParty,
-      paymentInstructions: paymentInstructions,
+      paymentInstructions: config.paymentInstructions,
+      messageId: config.messageId,
+      creationDate: config.creationDate,
     });
   }
 
   /**
    * Creates a SEPA Credit Payment Initiation message.
-   * @param {SEPACreditPaymentInstruction[]} paymentInstructions - An array of payment instructions.
+   * @param {SEPACreditPaymentInitiationConfig} config - Configuration containing payment instructions and optional parameters.
    * @example
-   * const payment = iso20022.createSEPACreditPaymentInitiation([
-   *   {
-   *     type: 'sepa',
-   *     direction: 'credit',
-   *     amount: 1000, // €10.00 Euros
-   *     currency: 'EUR',
-   *     creditor: {
-   *       name: 'Hans Schneider',
-   *       account: {
-   *         iban: 'DE1234567890123456',
+   * const payment = iso20022.createSEPACreditPaymentInitiation({
+   *   paymentInstructions: [
+   *     {
+   *       type: 'sepa',
+   *       direction: 'credit',
+   *       amount: 1000, // €10.00 Euros
+   *       currency: 'EUR',
+   *       creditor: {
+   *         name: 'Hans Schneider',
+   *         account: {
+   *           iban: 'DE1234567890123456',
+   *         },
    *       },
+   *       remittanceInformation: 'Invoice payment #123',
    *     },
-   *     remittanceInformation: 'Invoice payment #123',
-   *   },
-   * ]);
+   *   ],
+   *   messageId: 'SEPA-MSG-001', // Optional
+   *   creationDate: new Date('2025-03-01'), // Optional
+   * });
    * @returns {SEPACreditPaymentInitiation} A new SEPA Credit Payment Initiation object.
    */
   createSEPACreditPaymentInitiation(
-    paymentInstructions: AtLeastOne<SEPACreditPaymentInstruction>,
+    config: SEPACreditPaymentInitiationConfig,
   ) {
     return new SEPACreditPaymentInitiation({
       initiatingParty: this.initiatingParty,
-      paymentInstructions: paymentInstructions,
+      paymentInstructions: config.paymentInstructions,
+      messageId: config.messageId,
+      creationDate: config.creationDate,
     });
   }
 
   /**
    * Creates a RTP Credit Payment Initiation message.
-   * @param {RTPCreditPaymentInstruction[]} paymentInstructions - An array of payment instructions.
+   * @param {RTPCreditPaymentInitiationConfig} config - Configuration containing payment instructions and optional parameters.
    * @example
-   * const payment = iso20022.createRTPCreditPaymentInitiation([
-   *   {
-   *     type: 'rtp',
-   *     direction: 'credit',
-   *     amount: 100000, // $1000.00
-   *     currency: 'USD',
-   *     creditor: {
-   *       name: 'All-American Dogs Co.',
-   *       account: {
-   *         accountNumber: '123456789012',
+   * const payment = iso20022.createRTPCreditPaymentInitiation({
+   *   paymentInstructions: [
+   *     {
+   *       type: 'rtp',
+   *       direction: 'credit',
+   *       amount: 100000, // $1000.00
+   *       currency: 'USD',
+   *       creditor: {
+   *         name: 'All-American Dogs Co.',
+   *         account: {
+   *           accountNumber: '123456789012',
+   *         },
+   *         agent: {
+   *           abaRoutingNumber: '37714568112',
+   *         },
    *       },
-   *       agent: {
-   *         abaRoutingNumber: '37714568112',
-   *       },
+   *       remittanceInformation: '1000 Hot Dogs Feb26',
    *     },
-   *     remittanceInformation: '1000 Hot Dogs Feb26',
-   *   },
-   * ]);
+   *   ],
+   *   messageId: 'RTP-MSG-001', // Optional
+   *   creationDate: new Date('2025-03-01'), // Optional
+   * });
    * @returns {RTPCreditPaymentInitiation} A new RTP Credit Payment Initiation object.
    */
   createRTPCreditPaymentInitiation(
-    paymentInstructions: AtLeastOne<RTPCreditPaymentInstruction>,
+    config: RTPCreditPaymentInitiationConfig,
   ) {
     return new RTPCreditPaymentInitiation({
       initiatingParty: this.initiatingParty,
-      paymentInstructions: paymentInstructions,
+      paymentInstructions: config.paymentInstructions,
+      messageId: config.messageId,
+      creationDate: config.creationDate,
     });
   }
 }

--- a/test/pain/001/rtp-credit-payment-initiation.test.ts
+++ b/test/pain/001/rtp-credit-payment-initiation.test.ts
@@ -147,7 +147,9 @@ describe('RTPCreditPaymentInitiation', () => {
             })
 
             test('should create a RTPCreditPaymentInitiation instance', () => {
-                let rtpPayment = iso20022.createRTPCreditPaymentInitiation([paymentInstruction1]);
+                let rtpPayment = iso20022.createRTPCreditPaymentInitiation({
+                    paymentInstructions: [paymentInstruction1, paymentInstruction2]
+                });
                 const xml = rtpPayment.serialize();
                 const xsdSchema = fs.readFileSync(
                     `${process.cwd()}/schemas/pain/pain.001.001.03.xsd`,

--- a/test/pain/001/sepa-credit-payment-initiation.test.ts
+++ b/test/pain/001/sepa-credit-payment-initiation.test.ts
@@ -182,7 +182,9 @@ describe('SEPACreditPaymentInitiation', () => {
             })
 
             test('should create a SEPACreditPaymentInitiation instance', () => {
-                let sepaPayment = iso20022.createSEPACreditPaymentInitiation([paymentInstruction1]);
+                let sepaPayment = iso20022.createSEPACreditPaymentInitiation({
+                    paymentInstructions: [paymentInstruction1]
+                });
                 const xml = sepaPayment.serialize();
                 const xsdSchema = fs.readFileSync(
                     `${process.cwd()}/schemas/pain/pain.001.001.03.xsd`,

--- a/test/pain/001/swift-credit-payment-initiation.test.ts
+++ b/test/pain/001/swift-credit-payment-initiation.test.ts
@@ -67,9 +67,11 @@ describe('SWIFTCreditPaymentInitiation', () => {
         },
       });
 
-      swiftPayment = iso20022.createSWIFTCreditPaymentInitiation([
-        instruction1
-      ]);
+      swiftPayment = iso20022.createSWIFTCreditPaymentInitiation({
+        paymentInstructions: [
+          instruction1
+        ],
+      });
     });
 
   test('should create a SWIFTCreditPaymentInitiation instance', () => {
@@ -97,10 +99,11 @@ describe('SWIFTCreditPaymentInitiation', () => {
 
   describe('when there are multiple payment instructions', () => {
     beforeEach(() => {
-      swiftPayment = iso20022.createSWIFTCreditPaymentInitiation([
+      swiftPayment = iso20022.createSWIFTCreditPaymentInitiation({
+        paymentInstructions: [
         instruction1,
         instruction2,
-      ]);
+      ]});
     });
 
     test('serialized XML should validate against XSD', () => {


### PR DESCRIPTION
We need to match our repo to the docs. We should be able to do something like 

```
const creditPaymentInitiation = iso20022.createSEPACreditPaymentInitiation({
    paymentInstructions: [{
        type: 'sepa',
        direction: 'credit',
        amount: 1000,
        currency: 'EUR',
        creditor: {
            name: 'Kylian Mbappé',
            account: {
                iban: 'ES8201822200150201504058'
            },
        }
    }]
});
```

Currently we are not able to. The syntax is brittle and doesn't allow for better customization:

```
const creditPaymentInitiation = iso20022.createSEPACreditPaymentInitiation({
    [{
        type: 'sepa',
        direction: 'credit',
        amount: 1000,
        currency: 'EUR',
        creditor: {
            name: 'Kylian Mbappé',
            account: {
                iban: 'ES8201822200150201504058'
            },
        }
    }]
});
```

We are fixing it here.

Monitor in tests.

- **made updates**
- **removed turbo slop**
