### PR TITLE
Added .type to PaymentInitiation

### DIFF
--- a/src/pain/001/ach-credit-payment-initiation.ts
+++ b/src/pain/001/ach-credit-payment-initiation.ts
@@ -2,7 +2,7 @@ import { ABAAgent, ACHCreditPaymentInstruction, ACHLocalInstrument, ACHLocalInst
 import { v4 as uuidv4 } from 'uuid';
 import Dinero, { Currency } from 'dinero.js';
 import { sanitize } from '../../utils/format';
-import { PaymentInitiation } from './iso20022-payment-initiation';
+import { PaymentInitiation } from './payment-initiation';
 import { XMLParser } from 'fast-xml-parser';
 import { InvalidXmlError, InvalidXmlNamespaceError } from "../../errors";
 import { parseAccount, parseAgent, parseAmountToMinorUnits } from "../../parseUtils";
@@ -88,7 +88,7 @@ export class ACHCreditPaymentInitiation extends PaymentInitiation {
     private formattedPaymentSum: string;
     
     constructor(config: ACHCreditPaymentInitiationConfig) {
-        super();
+        super({ type: "ach" });
         this.initiatingParty = config.initiatingParty;
         this.paymentInstructions = config.paymentInstructions;
         this.messageId = config.messageId || uuidv4().replace(/-/g, '');

--- a/src/pain/001/payment-initiation.ts
+++ b/src/pain/001/payment-initiation.ts
@@ -14,6 +14,12 @@ import {
    * @abstract
    */
   export abstract class PaymentInitiation {
+    public type: "swift" | "rtp" | "sepa" | "ach";
+
+    constructor({ type }: { type: "swift" | "rtp" | "sepa" | "ach" }) {
+      this.type = type;
+    }
+
     /**
      * Serializes the payment initiation to a string format.
      * @abstract

--- a/src/pain/001/rtp-credit-payment-initiation.ts
+++ b/src/pain/001/rtp-credit-payment-initiation.ts
@@ -2,7 +2,7 @@ import { ABAAgent, Account, Agent, BaseAccount, Party, RTPCreditPaymentInstructi
 import { v4 as uuidv4 } from 'uuid';
 import Dinero, { Currency } from 'dinero.js';
 import { sanitize } from '../../utils/format';
-import { PaymentInitiation } from './iso20022-payment-initiation';
+import { PaymentInitiation } from './payment-initiation';
 import { XMLParser } from 'fast-xml-parser';
 import { InvalidXmlError, InvalidXmlNamespaceError } from "../../errors";
 import { parseAccount, parseAgent, parseAmountToMinorUnits } from "../../parseUtils";
@@ -58,7 +58,7 @@ export class RTPCreditPaymentInitiation extends PaymentInitiation {
     public paymentInformationId: string;
     private formattedPaymentSum: string;
     constructor(config: RTPCreditPaymentInitiationConfig) {
-        super();
+        super({ type: "rtp" });
         this.initiatingParty = config.initiatingParty;
         this.paymentInstructions = config.paymentInstructions;
         this.messageId = config.messageId || uuidv4().replace(/-/g, '');

--- a/src/pain/001/sepa-credit-payment-initiation.ts
+++ b/src/pain/001/sepa-credit-payment-initiation.ts
@@ -1,5 +1,5 @@
 import { Account, Agent, BICAgent, ExternalCategoryPurpose, IBANAccount, Party, SEPACreditPaymentInstruction } from "../../lib/types";
-import { PaymentInitiation } from './iso20022-payment-initiation';
+import { PaymentInitiation } from './payment-initiation';
 import { sanitize } from "../../utils/format";
 import Dinero, { Currency } from 'dinero.js';
 import { v4 as uuidv4 } from 'uuid';
@@ -67,7 +67,7 @@ export class SEPACreditPaymentInitiation extends PaymentInitiation {
    * @param {SEPACreditPaymentInitiationConfig} config - The configuration object for the SEPA credit transfer.
    */
   constructor(config: SEPACreditPaymentInitiationConfig) {
-    super();
+    super({ type: "sepa" });
     this.initiatingParty = config.initiatingParty;
     this.paymentInstructions = config.paymentInstructions;
     this.messageId = config.messageId || uuidv4().replace(/-/g, '');

--- a/src/pain/001/swift-credit-payment-initiation.ts
+++ b/src/pain/001/swift-credit-payment-initiation.ts
@@ -12,7 +12,7 @@ import {
 } from '../../lib/types.js';
 import { parseAccount, parseAmountToMinorUnits } from "../../parseUtils";
 import { sanitize } from '../../utils/format';
-import { PaymentInitiation } from './iso20022-payment-initiation';
+import { PaymentInitiation } from './payment-initiation';
 
 type AtLeastOne<T> = [T, ...T[]];
 
@@ -66,7 +66,7 @@ export class SWIFTCreditPaymentInitiation extends PaymentInitiation {
    * @param {SWIFTCreditPaymentInitiationConfig} config - The configuration object.
    */
   constructor(config: SWIFTCreditPaymentInitiationConfig) {
-    super();
+    super({ type: "swift" });
     this.initiatingParty = config.initiatingParty;
     this.paymentInstructions = config.paymentInstructions;
     this.messageId =


### PR DESCRIPTION
In anticipation for the Fiat Web Services API, it should be possible to track the "type" of a Payment Initiation object.


This is done by "sepa" or "swift". It must be done by the parent class.

This will be useful later
