### PR TITLE
Make type and direction coercion optional

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,15 +24,39 @@ export interface PaymentInstruction {
 }
 
 /**
+ * Represents a credit payment instruction, extending the base PaymentInstruction.
+ */
+export interface CreditPaymentInstruction extends PaymentInstruction {
+  direction: 'credit';
+  creditor: Party;
+}
+
+/**
  * Represents a SWIFT credit payment instruction, extending the base PaymentInstruction.
  */
-export interface SWIFTCreditPaymentInstruction extends PaymentInstruction {
+export interface SWIFTCreditPaymentInstruction extends CreditPaymentInstruction {
   /** Specifies that this is a SWIFT payment. */
-  type: 'swift';
-  /** SWIFT payments are always credit payments. */
-  direction: 'credit';
-  /** The party to which the payment is credited (required for SWIFT payments). */
-  creditor: Party;
+  type?: 'swift';
+}
+
+export interface SEPACreditPaymentInstruction extends CreditPaymentInstruction {
+  type?: 'sepa',
+  currency: 'EUR',
+}
+
+export interface RTPCreditPaymentInstruction extends CreditPaymentInstruction {
+  type?: 'rtp',
+  currency: 'USD',
+}
+
+/**
+ * Represents an ACH credit payment instruction, extending the base PaymentInstruction.
+ */
+export interface ACHCreditPaymentInstruction extends CreditPaymentInstruction {
+  /** Specifies that this is an ACH payment. */
+  type?: 'ach',
+  /** ACH payments must use USD as currency. */
+  currency: 'USD',
 }
 
 /*
@@ -191,33 +215,6 @@ export const ExternalCategoryPurposeCodeDescriptionMap = {
 
 export type ExternalCategoryPurpose =
   (typeof ExternalCategoryPurposeCode)[keyof typeof ExternalCategoryPurposeCode];
-
-export interface SEPACreditPaymentInstruction extends PaymentInstruction {
-  type: 'sepa',
-  direction: 'credit',
-  creditor: Party,
-}
-
-export interface RTPCreditPaymentInstruction extends PaymentInstruction {
-  type: 'rtp',
-  direction: 'credit',
-  currency: 'USD',
-  creditor: Party,
-}
-
-/**
- * Represents an ACH credit payment instruction, extending the base PaymentInstruction.
- */
-export interface ACHCreditPaymentInstruction extends PaymentInstruction {
-  /** Specifies that this is an ACH payment. */
-  type: 'ach',
-  /** ACH payments are always credit payments. */
-  direction: 'credit',
-  /** ACH payments must use USD as currency. */
-  currency: 'USD',
-  /** The party to which the payment is credited (required for ACH payments). */
-  creditor: Party,
-}
 
 /**
  * Represents a structured address format.

--- a/test/pain/001/sepa-credit-payment-initiation.test.ts
+++ b/test/pain/001/sepa-credit-payment-initiation.test.ts
@@ -167,15 +167,6 @@ describe('SEPACreditPaymentInitiation', () => {
             expect(xml).toMatch(/<InstdAmt[^>]*Ccy="EUR"[^>]*>/);
         });
 
-        describe('should fail is there are different payment instruction currencies', () => {
-            it('should throw an error', () => {
-                expect(() => {
-                    sepaPaymentInitiationConfig.paymentInstructions[1].currency = "USD" // Change currency
-                    new SEPACreditPaymentInitiation(sepaPaymentInitiationConfig)
-                }).toThrow("In order to calculate the payment instructions sum, all payment instruction currencies must be the same.");
-            });
-        });
-
         describe('created with iso20022', () => {
             let iso20022 = new ISO20022({
                 initiatingParty: initiatingParty


### PR DESCRIPTION
In CreditPaymentInstructions, we technically don't need a credit or debit, or even explicit payment types. We should make sure that if it is placed, it is force to be corret. We can allow interpretability through this change.
