### PR TITLE
feat: migrate from Dinero.js v1 to v2

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,8 +3,9 @@ module.exports = {
   testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  transformIgnorePatterns: ['/node_modules/(?!dinero\\.js)'],
   transform: {
-    '^.+\\.tsx?$': [
+    '^.+\\.[tj]sx?$': [
       'ts-jest',
       {
         tsconfig: 'tsconfig.json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "iso20022.js",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iso20022.js",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
-        "dinero.js": "^1.9.1",
+        "dinero.js": "^2.0.0",
         "fast-xml-parser": "^4.4.1",
         "uuid": "^10.0.0"
       },
@@ -20,7 +20,6 @@
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-typescript": "^11.1.6",
-        "@types/dinero.js": "^1.9.4",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.12",
         "@types/uuid": "^10.0.0",
@@ -82,6 +81,7 @@
       "integrity": "sha512-Oixnb+DzmRT30qu9d3tJSQkxuygWm32DFykT4bRoORPa9hZ/L4KhVB/XiRm6KG+roIEM7DBQlmg27kw2HZkdZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.25.7",
@@ -2511,13 +2511,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/dinero.js": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@types/dinero.js/-/dinero.js-1.9.4.tgz",
-      "integrity": "sha512-mtJnan4ajy9MqvoJGVXu0tC9EAAzFjeoKc3d+8AW+H/Od9+8IiC59ymjrZF+JdTToyDvkLReacTsc50Z8eYr6Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2579,6 +2572,7 @@
       "integrity": "sha512-vtgGzjxLF7QT88qRHtXMzCWpAAmwonE7fwgVjFtXosUva2oSpnIEc3gNO9P7uIfOxKnii2f79/xtOnfreYtDaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -3004,6 +2998,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -3597,12 +3592,12 @@
       }
     },
     "node_modules/dinero.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/dinero.js/-/dinero.js-1.9.1.tgz",
-      "integrity": "sha512-1HXiF2vv3ZeRQ23yr+9lFxj/PbZqutuYWJnE0qfCB9xYBPnuaJ8lXtli1cJM0TvUXW1JTOaePldmqN5JVNxKSA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dinero.js/-/dinero.js-2.0.0.tgz",
+      "integrity": "sha512-UTbFNSTA+7PBFQrubw004/mGxH8GPLL7a4NKoZJGISd9Pwe9YQsxJw+gO5kYRef0EiMLOptE6DH1mMBev7eQjQ==",
       "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/eastasianwidth": {
@@ -4631,6 +4626,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7686,6 +7682,7 @@
       "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -8324,6 +8321,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -8367,7 +8365,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
       "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.20.5",
@@ -8417,6 +8416,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iso20022.js",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "readme": "README.md",
   "description": "Library to create payment messages.",
   "main": "dist/index.js",
@@ -56,7 +56,6 @@
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",
-    "@types/dinero.js": "^1.9.4",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.12",
     "@types/uuid": "^10.0.0",
@@ -74,7 +73,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "dinero.js": "^1.9.1",
+    "dinero.js": "^2.0.0",
     "fast-xml-parser": "^4.4.1",
     "uuid": "^10.0.0"
   }

--- a/src/camt/004/cash-management-return-account.ts
+++ b/src/camt/004/cash-management-return-account.ts
@@ -4,7 +4,7 @@ import { GenericISO20022Message, ISO20022Messages, ISO20022MessageTypeName, regi
 import { AccountIdentification, CashAccountType, MessageHeader } from "../../lib/types";
 import { exportAccountIdentification, exportMessageHeader, parseAccountIdentification, parseMessageHeader } from "../../parseUtils";
 import { exportBalanceReport, exportBusinessError, parseBalanceReport, parseBusinessError } from "../utils";
-import { Currency } from "dinero.js";
+import { Currency } from "../../lib/currency";
 
 export interface AccountReport {
   currency: Currency;

--- a/src/camt/006/cash-management-return-transaction.ts
+++ b/src/camt/006/cash-management-return-transaction.ts
@@ -4,7 +4,7 @@ import { GenericISO20022Message, ISO20022Messages, ISO20022MessageTypeName, regi
 import { Agent, MessageHeader, Party } from "../../lib/types";
 import { exportAmountToString, exportMessageHeader, parseAmountToMinorUnits, parseDate, parseMessageHeader, parseParty as parsePartyExt} from "../../parseUtils";
 import { exportBusinessError, parseBusinessError } from "../utils";
-import { Currency } from "dinero.js";
+import { Currency } from "../../lib/currency";
 
 export interface TransactionReport {
   msgId?: string;

--- a/src/camt/types.ts
+++ b/src/camt/types.ts
@@ -1,6 +1,6 @@
 // Types related to CAMT 053
 
-import { Currency } from 'dinero.js';
+import { Currency } from '../lib/currency';
 import { Account, Agent, Party } from '../lib/types';
 
 /**

--- a/src/camt/utils.ts
+++ b/src/camt/utils.ts
@@ -14,7 +14,7 @@ import {
   parseAgent,
   parseAmountToMinorUnits,
 } from '../parseUtils';
-import { Currency } from 'dinero.js';
+import { Currency } from '../lib/currency';
 
 export const parseStatement = (stmt: any): Statement => {
   const id = stmt.Id.toString();

--- a/src/dinero-helpers.ts
+++ b/src/dinero-helpers.ts
@@ -1,0 +1,34 @@
+import { dinero, add, toDecimal, type Dinero, type DineroSnapshot } from 'dinero.js';
+import { getCurrencyPrecision } from './lib/currencies';
+import { Currency } from './lib/currency';
+
+type DineroCurrency = { code: string; base: number; exponent: number };
+
+export function currencyObj(code: Currency): DineroCurrency {
+  return { code, base: 10, exponent: getCurrencyPrecision(code) };
+}
+
+export function createDinero(amount: number, currency: Currency) {
+  return dinero({ amount, currency: currencyObj(currency) });
+}
+
+export function formatDinero(d: Dinero<number>): string {
+  return toDecimal(d, ({ value, currency }) => {
+    const exponent = currency.exponent;
+    const parts = value.split('.');
+    const intPart = parts[0];
+    const decPart = (parts[1] || '').padEnd(exponent, '0');
+    return exponent > 0 ? `${intPart}.${decPart}` : intPart;
+  });
+}
+
+export function formatAmount(amount: number, currency: Currency): string {
+  return formatDinero(createDinero(amount, currency));
+}
+
+export function sumAmounts(amounts: number[], currency: Currency): string {
+  const curr = currencyObj(currency);
+  const dineros = amounts.map(amount => dinero({ amount, currency: curr }));
+  const total = dineros.reduce((acc, next) => add(acc, next));
+  return formatDinero(total);
+}

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,0 +1,5 @@
+/**
+ * ISO 4217 currency code.
+ * This replaces the Currency type from dinero.js v1.
+ */
+export type Currency = string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { Currency } from 'dinero.js';
+import { Currency } from './currency';
 import { Alpha2Country } from './countries';
 
 /**
@@ -335,7 +335,7 @@ export const ACHLocalInstrumentCode = {
   RepresentedCheck: 'RCK',
 } as const;
 
-export type ACHLocalInstrument = 
+export type ACHLocalInstrument =
   (typeof ACHLocalInstrumentCode)[keyof typeof ACHLocalInstrumentCode];
 
 export const ACHLocalInstrumentCodeDescriptionMap = {
@@ -357,7 +357,7 @@ export interface MessageHeader {
   queryName?: string;
 }
 
-/* From ISO specifications 
+/* From ISO specifications
 Code  Name  Definition
 CACC	Current	Account used to post debits and credits when no specific account has been nominated.
 CASH	CashPayment	Account used for the payment of cash.
@@ -367,7 +367,7 @@ CISH	CashIncome	Account used for payment of income if different from the current
 COMM	Commission	"Account used for commission if different from the account
 for payment."
 CPAC	ClearingParticipantSettlementAccount	Account used to post settlement debit and credit entries on behalf of a designated Clearing Participant.
-LLSV	LimitedLiquiditySavingsAccount	Account used for savings with special interest and withdrawal terms.  
+LLSV	LimitedLiquiditySavingsAccount	Account used for savings with special interest and withdrawal terms.
 LOAN	Loan	Account used for loans.
 MGLD	Marginal Lending	Account used for a marginal lending facility.
 MOMA	Money Market	"Account used for money markets if different from the cash
@@ -375,7 +375,7 @@ account."
 NREX	NonResidentExternal	Account used for non-resident external.
 ODFT	Overdraft	Account is used for overdrafts.
 ONDP	OverNightDeposit	Account used for overnight deposits.
-OTHR	OtherAccount	Account not otherwise specified. 
+OTHR	OtherAccount	Account not otherwise specified.
 SACC	Settlement	Account used to post debit and credit entries, as a result of transactions cleared and settled through a specific clearing and settlement system.
 SLRY	Salary	Accounts used for salary payments.
 SVGS	Savings	Account used for savings.
@@ -411,7 +411,7 @@ export const CashAccountTypeCode = {
 
 export type CashAccountType =
   (typeof CashAccountTypeCode)[keyof typeof CashAccountTypeCode];
-  
+
 export const CashAccountTypeCodeDescriptionMap = {
   'CACC': 'Current',
   'CASH': 'Cash Payment',

--- a/src/pain/001/ach-credit-payment-initiation.ts
+++ b/src/pain/001/ach-credit-payment-initiation.ts
@@ -1,6 +1,7 @@
 import { ABAAgent, ACHCreditPaymentInstruction, ACHLocalInstrument, ACHLocalInstrumentCode, Account, Agent, BaseAccount, Party } from '../../lib/types';
 import { v4 as uuidv4 } from 'uuid';
-import Dinero, { Currency } from 'dinero.js';
+import { Currency } from '../../lib/currency';
+import { formatAmount, sumAmounts } from '../../dinero-helpers';
 import { sanitize } from '../../utils/format';
 import { PaymentInitiation } from './payment-initiation';
 import { XMLParser } from 'fast-xml-parser';
@@ -68,10 +69,10 @@ export interface ACHCreditPaymentInitiationConfig {
  *     }
  *   }]
  * });
- * 
+ *
  * // Serializing to XML
  * const xml = payment.serialize();
- * 
+ *
  * // Parsing from XML
  * const parsedPayment = ACHCreditPaymentInitiation.fromXML(xml);
  * ```
@@ -86,7 +87,7 @@ export class ACHCreditPaymentInitiation extends PaymentInitiation {
     public serviceLevel: string;
     public instructionPriority: string;
     private formattedPaymentSum: string;
-    
+
     constructor(config: ACHCreditPaymentInitiationConfig) {
         super({ type: "ach" });
         this.initiatingParty = config.initiatingParty;
@@ -100,7 +101,7 @@ export class ACHCreditPaymentInitiation extends PaymentInitiation {
         this.formattedPaymentSum = this.sumPaymentInstructions(this.paymentInstructions as AtLeastOne<ACHCreditPaymentInstruction>);
         this.validate();
     }
-    
+
     /**
      * Calculates the sum of all payment instructions.
      * @private
@@ -109,13 +110,10 @@ export class ACHCreditPaymentInitiation extends PaymentInitiation {
      * @throws {Error} If payment instructions have different currencies.
      */
     private sumPaymentInstructions(instructions: AtLeastOne<ACHCreditPaymentInstruction>): string {
-        const instructionDineros = instructions.map(instruction => Dinero({ amount: instruction.amount, currency: instruction.currency }));
-        return instructionDineros.reduce(
-            (acc: Dinero.Dinero, next): Dinero.Dinero => {
-                return acc.add(next as Dinero.Dinero);
-            },
-            Dinero({ amount: 0, currency: instructions[0].currency }),
-        ).toFormat('0.00');
+        return sumAmounts(
+            instructions.map(i => i.amount),
+            instructions[0].currency,
+        );
     }
 
     /**
@@ -129,7 +127,7 @@ export class ACHCreditPaymentInitiation extends PaymentInitiation {
         if (this.messageId.length > 35) {
             throw new Error('messageId must not exceed 35 characters');
         }
-        
+
         // Ensure all payment instructions have USD as currency
         for (const instruction of this.paymentInstructions) {
             if (instruction.currency !== 'USD') {
@@ -146,7 +144,6 @@ export class ACHCreditPaymentInitiation extends PaymentInitiation {
     creditTransfer(instruction: ACHCreditPaymentInstruction) {
         const paymentInstructionId = sanitize(instruction.id || uuidv4(), 35);
         const endToEndId = sanitize(instruction.endToEndId || instruction.id || uuidv4(), 35);
-        const dinero = Dinero({ amount: instruction.amount, currency: instruction.currency });
 
         return {
             PmtId: {
@@ -155,7 +152,7 @@ export class ACHCreditPaymentInitiation extends PaymentInitiation {
             },
             Amt: {
                 InstdAmt: {
-                    '#': dinero.toFormat('0.00'),
+                    '#': formatAmount(instruction.amount, instruction.currency),
                     '@Ccy': instruction.currency,
                 },
             },

--- a/src/pain/001/rtp-credit-payment-initiation.ts
+++ b/src/pain/001/rtp-credit-payment-initiation.ts
@@ -1,6 +1,7 @@
 import { ABAAgent, Account, Agent, BaseAccount, Party, RTPCreditPaymentInstruction } from '../../lib/types';
 import { v4 as uuidv4 } from 'uuid';
-import Dinero, { Currency } from 'dinero.js';
+import { Currency } from '../../lib/currency';
+import { formatAmount, sumAmounts } from '../../dinero-helpers';
 import { sanitize } from '../../utils/format';
 import { PaymentInitiation } from './payment-initiation';
 import { XMLParser } from 'fast-xml-parser';
@@ -75,13 +76,10 @@ export class RTPCreditPaymentInitiation extends PaymentInitiation {
      * @throws {Error} If payment instructions have different currencies.
      */
     private sumPaymentInstructions(instructions: AtLeastOne<RTPCreditPaymentInstruction>): string {
-        const instructionDineros = instructions.map(instruction => Dinero({ amount: instruction.amount, currency: instruction.currency }));
-        return instructionDineros.reduce(
-            (acc: Dinero.Dinero, next): Dinero.Dinero => {
-                return acc.add(next as Dinero.Dinero);
-            },
-            Dinero({ amount: 0, currency: instructions[0].currency }),
-        ).toFormat('0.00');
+        return sumAmounts(
+            instructions.map(i => i.amount),
+            instructions[0].currency,
+        );
     }
 
     /**
@@ -105,7 +103,6 @@ export class RTPCreditPaymentInitiation extends PaymentInitiation {
     creditTransfer(instruction: RTPCreditPaymentInstruction) {
         const paymentInstructionId = sanitize(instruction.id || uuidv4(), 35);
         const endToEndId = sanitize(instruction.endToEndId || instruction.id || uuidv4(), 35);
-        const dinero = Dinero({ amount: instruction.amount, currency: instruction.currency });
 
         return {
             PmtId: {
@@ -114,7 +111,7 @@ export class RTPCreditPaymentInitiation extends PaymentInitiation {
             },
             Amt: {
                 InstdAmt: {
-                    '#': dinero.toFormat('0.00'),
+                    '#': formatAmount(instruction.amount, instruction.currency),
                     '@Ccy': instruction.currency,
                 },
             },

--- a/src/pain/001/sepa-credit-payment-initiation.ts
+++ b/src/pain/001/sepa-credit-payment-initiation.ts
@@ -1,7 +1,8 @@
 import { Account, Agent, BICAgent, ExternalCategoryPurpose, IBANAccount, Party, SEPACreditPaymentInstruction } from "../../lib/types";
 import { PaymentInitiation } from './payment-initiation';
 import { sanitize } from "../../utils/format";
-import Dinero, { Currency } from 'dinero.js';
+import { Currency } from '../../lib/currency';
+import { formatAmount, sumAmounts } from '../../dinero-helpers';
 import { v4 as uuidv4 } from 'uuid';
 import { XMLParser } from 'fast-xml-parser';
 import { InvalidXmlError, InvalidXmlNamespaceError } from "../../errors";
@@ -91,13 +92,10 @@ export class SEPACreditPaymentInitiation extends PaymentInitiation {
    */
   private sumPaymentInstructions(instructions: AtLeastOne<SEPACreditPaymentInstruction>): string {
     this.validateAllInstructionsHaveSameCurrency();
-    const instructionDineros = instructions.map(instruction => Dinero({ amount: instruction.amount, currency: instruction.currency }));
-    return instructionDineros.reduce(
-      (acc: Dinero.Dinero, next): Dinero.Dinero => {
-        return acc.add(next as Dinero.Dinero);
-      },
-      Dinero({ amount: 0, currency: instructions[0].currency }),
-    ).toFormat('0.00');
+    return sumAmounts(
+      instructions.map(i => i.amount),
+      instructions[0].currency,
+    );
   }
 
   /**
@@ -133,7 +131,6 @@ export class SEPACreditPaymentInitiation extends PaymentInitiation {
   creditTransfer(instruction: SEPACreditPaymentInstruction) {
     const paymentInstructionId = sanitize(instruction.id || uuidv4(), 35);
     const endToEndId = sanitize(instruction.endToEndId || instruction.id || uuidv4(), 35);
-    const dinero = Dinero({ amount: instruction.amount, currency: instruction.currency });
 
     return {
       PmtId: {
@@ -142,7 +139,7 @@ export class SEPACreditPaymentInitiation extends PaymentInitiation {
       },
       Amt: {
         InstdAmt: {
-          '#': dinero.toFormat('0.00'),
+          '#': formatAmount(instruction.amount, instruction.currency),
           '@Ccy': instruction.currency,
         },
       },

--- a/src/pain/001/swift-credit-payment-initiation.ts
+++ b/src/pain/001/swift-credit-payment-initiation.ts
@@ -1,8 +1,10 @@
-import Dinero, { Currency } from 'dinero.js';
+import { dinero, toDecimal } from 'dinero.js';
 import { XMLBuilder, XMLParser } from 'fast-xml-parser';
 import { v4 as uuidv4 } from 'uuid';
 import { InvalidXmlError, InvalidXmlNamespaceError } from "../../errors";
 import { Alpha2Country } from "../../lib/countries";
+import { Currency } from '../../lib/currency';
+import { formatAmount, currencyObj } from '../../dinero-helpers';
 import {
   Account,
   BICAgent,
@@ -113,10 +115,9 @@ export class SWIFTCreditPaymentInitiation extends PaymentInitiation {
    */
   creditTransfer(paymentInstruction: SWIFTCreditPaymentInstruction): Record<string, any> {
     const paymentInstructionId = sanitize(paymentInstruction.id || uuidv4(), 35);
-    const amount = Dinero({
-      amount: paymentInstruction.amount,
-      currency: paymentInstruction.currency,
-    }).toUnit();
+    const curr = currencyObj(paymentInstruction.currency);
+    const d = dinero({ amount: paymentInstruction.amount, currency: curr });
+    const amount = toDecimal(d);
 
     return {
       PmtId: {

--- a/src/parseUtils.ts
+++ b/src/parseUtils.ts
@@ -1,6 +1,7 @@
 import { Account, AccountIdentification, AccountIdentificationIBAN, AccountIdentificationOther, Agent, BaseAccount, IBANAccount, MessageHeader, Party, StructuredAddress } from 'lib/types';
 import { getCurrencyPrecision } from './lib/currencies';
-import Dinero, { Currency } from 'dinero.js';
+import { Currency } from './lib/currency';
+import { formatAmount } from './dinero-helpers';
 
 export const parseAccount = (account: any): Account => {
   // Return just IBAN if it exists, else detailed local account details
@@ -95,31 +96,21 @@ export const exportAgent = (agent: Agent): any => {
   return obj;
 };
 
-// Parse raw currency data, turn into Dinero object and turn into minor units
+// Parse raw currency data and turn into minor units
 export const parseAmountToMinorUnits = (
   rawAmount: number,
   currency: Currency = 'USD',
 ): number => {
-  const currencyObject = Dinero({
-    currency: currency,
-    precision: getCurrencyPrecision(currency),
-  });
+  const precision = getCurrencyPrecision(currency);
   // Also make sure Javascript number parsing error do not happen.
-  return Math.floor(Number(rawAmount) * 10 ** currencyObject.getPrecision());
+  return Math.floor(Number(rawAmount) * 10 ** precision);
 };
 
 export const exportAmountToString = (
   amount: number,
   currency: Currency = 'USD',
 ): string => {
-  const currencyObject = Dinero({
-    amount,
-    currency: currency,
-    precision: getCurrencyPrecision(currency),
-  });
-  const precision = currencyObject.getPrecision();
-  const zeroes = '0'.repeat(precision);
-  return currencyObject.toFormat('0'+(zeroes.length > 0 ? '.'+zeroes : ''));
+  return formatAmount(amount, currency);
 }
 
 export const parseDate = (dateElement: any): Date => {

--- a/test/pain/001/ach-credit-payment-initiation.test.ts
+++ b/test/pain/001/ach-credit-payment-initiation.test.ts
@@ -5,7 +5,7 @@ import { Alpha2Country } from "../../../src/lib/countries";
 import ISO20022 from '../../../src/iso20022';
 import { v4 as uuidv4 } from 'uuid';
 import { ABAAgent, BaseAccount } from "../../../src/lib/types";
-import { Currency } from "dinero.js";
+import { Currency } from "../../../src/lib/currency";
 
 describe('ACHCreditPaymentInitiation', () => {
     let achPaymentInitiationConfig: ACHCreditPaymentInitiationConfig;


### PR DESCRIPTION
## Summary

- Upgrade `dinero.js` from v1.9.1 to v2.0.0
- Remove `@types/dinero.js` (v2 ships its own TypeScript types)
- Migrate from Dinero v1's chainable API to v2's functional API
- Add `src/lib/currency.ts` with a local `Currency` type alias (replaces the one from `dinero.js` v1)
- Add `src/dinero-helpers.ts` with shared utilities for creating and formatting Dinero objects

### Migration details

| Dinero v1 | Dinero v2 |
|-----------|-----------|
| `import Dinero, { Currency } from 'dinero.js'` | `import { dinero, add, toDecimal } from 'dinero.js'` + local `Currency` type |
| `Dinero({ amount, currency })` | `dinero({ amount, currency: { code, base: 10, exponent } })` |
| `d1.add(d2)` | `add(d1, d2)` |
| `d.toFormat('0.00')` | `toDecimal(d)` with custom formatter |
| `d.toUnit()` | `toDecimal(d)` |
| `d.getPrecision()` | Currency `exponent` property |